### PR TITLE
Adding vaxrank HTML/PDF output, with some associated changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,6 @@ target/
 
 # Generated outputs
 vaccine-peptides-report.txt
+vaccine-peptides-report.html
+vaccine-peptides-report.pdf
 vaccine-peptides.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ varcode>=0.4.19
 isovar>=0.2.1
 mhctools>=0.3.0
 roman
+jinja2
+pdfkit  # needs wkhtmltopdf: brew install Caskroom/cask/wkhtmltopdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six
 pandas
 pyensembl>=0.9.6
 varcode>=0.4.19
-isovar>=0.2.1
+isovar>=0.2.2
 mhctools>=0.3.0
 roman
 jinja2

--- a/run-vaxrank-b16-test-data.sh
+++ b/run-vaxrank-b16-test-data.sh
@@ -4,4 +4,5 @@ vaxrank \
     --vaccine-peptide-length 25 \
     --mhc-predictor netmhc \
     --mhc-alleles H2-Kb,H2-Db \
-    --padding-around-mutation 5 --output-ascii-report vaccine-peptides-report.txt
+    --padding-around-mutation 5 \
+    --output-ascii-report vaccine-peptides-report.txt

--- a/run-vaxrank-b16-test-data.sh
+++ b/run-vaxrank-b16-test-data.sh
@@ -4,4 +4,4 @@ vaxrank \
     --vaccine-peptide-length 25 \
     --mhc-predictor netmhc \
     --mhc-alleles H2-Kb,H2-Db \
-    --padding-around-mutation 5
+    --padding-around-mutation 5 --output-ascii-report vaccine-peptides-report.txt

--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,13 @@ if __name__ == '__main__':
         install_requires=[
             'six',
             'pandas',
-            'pyensembl>=0.9.5',
+            'pyensembl>=0.9.6',
             'varcode>=0.4.19',
             'isovar>=0.2.1',
             'mhctools>=0.3.0',
             'roman',
+            'jinja2',
+            'pdfkit',
         ],
 
         long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
             'pandas',
             'pyensembl>=0.9.6',
             'varcode>=0.4.19',
-            'isovar>=0.2.1',
+            'isovar>=0.2.2',
             'mhctools>=0.3.0',
             'roman',
             'jinja2',

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -25,12 +25,14 @@ from mhctools.cli import (
 from isovar.cli.variant_sequences import make_variant_sequences_arg_parser
 from isovar.cli.rna_reads import allele_reads_generator_from_args
 
-
 from .core_logic import ranked_vaccine_peptides, dataframe_from_ranked_list
 from .report import (
-    make_ascii_report_from_ranked_vaccine_peptides,
-    make_html_report_from_ranked_vaccine_peptides,
+    compute_template_data,
+    make_ascii_report,
+    make_html_report,
+    make_pdf_report,
 )
+
 
 # inherit all commandline options from Isovar
 arg_parser = make_variant_sequences_arg_parser(
@@ -49,17 +51,17 @@ arg_parser.add_argument(
 
 arg_parser.add_argument(
     "--output-ascii-report",
-    default="vaccine-peptides-report.txt",
+    default="",
     help="Path to ASCII vaccine peptide report")
 
 arg_parser.add_argument(
     "--output-html-report",
-    default="vaccine-peptides-report.html",
+    default="",
     help="Path to HTML vaccine peptide report")
 
 arg_parser.add_argument(
     "--output-pdf-report",
-    default="vaccine-peptides-report.pdf",
+    default="",
     help="Path to PDF vaccine peptide report")
 
 vaccine_peptide_group = arg_parser.add_argument_group("Vaccine peptide options")
@@ -133,17 +135,23 @@ def main(args_list=None):
 
     df.to_csv(args.output_csv, index=False)
 
-    make_ascii_report_from_ranked_vaccine_peptides(
+    template_data = compute_template_data(
         ranked_variants_with_vaccine_peptides=ranked_list,
         mhc_alleles=mhc_alleles,
         variants=variants,
-        bam_path=args.bam,
-        ascii_report_path=args.output_ascii_report)
+        bam_path=args.bam)
 
-    make_html_report_from_ranked_vaccine_peptides(
-        ranked_variants_with_vaccine_peptides=ranked_list,
-        mhc_alleles=mhc_alleles,
-        variants=variants,
-        bam_path=args.bam,
-        html_report_path=args.output_html_report,
-        pdf_report_path=args.output_pdf_report)
+    if args.output_ascii_report:
+        make_ascii_report(
+            template_data=template_data,
+            ascii_report_path=args.output_ascii_report)
+
+    if args.output_html_report:
+        make_html_report(
+            template_data=template_data,
+            html_report_path=args.output_html_report)
+
+    if args.output_pdf_report:
+        make_pdf_report(
+            template_data=template_data,
+            pdf_report_path=args.output_pdf_report)

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -109,13 +109,17 @@ def main(args_list=None):
 
     logging.basicConfig(level=logging.DEBUG)
     args = arg_parser.parse_args(args_list)
-    print(args)
+    logging.info(args)
+
+    if not (args.output_ascii_report or args.output_html_report or args.output_pdf_report):
+        raise ValueError('Must specify at least one of: --output-ascii-report, '
+            '--output-html-report, --output-pdf-report') 
 
     variants = variant_collection_from_args(args)
-    print(variants)
+    logging.info(variants)
 
     mhc_alleles = mhc_alleles_from_args(args)
-    print("MHC alleles: %s" % (mhc_alleles,))
+    logging.info("MHC alleles: %s" % (mhc_alleles,))
     mhc_predictor = mhc_binding_predictor_from_args(args)
 
     # generator that for each variant gathers all RNA reads, both those
@@ -131,7 +135,7 @@ def main(args_list=None):
         min_reads_supporting_cdna_sequence=args.min_reads_supporting_variant_sequence)
 
     df = dataframe_from_ranked_list(ranked_list)
-    print(df)
+    logging.info(df)
 
     df.to_csv(args.output_csv, index=False)
 

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -27,7 +27,10 @@ from isovar.cli.rna_reads import allele_reads_generator_from_args
 
 
 from .core_logic import ranked_vaccine_peptides, dataframe_from_ranked_list
-from .report import ascii_report_from_ranked_vaccine_peptides
+from .report import (
+    make_ascii_report_from_ranked_vaccine_peptides,
+    make_html_report_from_ranked_vaccine_peptides,
+)
 
 # inherit all commandline options from Isovar
 arg_parser = make_variant_sequences_arg_parser(
@@ -48,6 +51,16 @@ arg_parser.add_argument(
     "--output-ascii-report",
     default="vaccine-peptides-report.txt",
     help="Path to ASCII vaccine peptide report")
+
+arg_parser.add_argument(
+    "--output-html-report",
+    default="vaccine-peptides-report.html",
+    help="Path to HTML vaccine peptide report")
+
+arg_parser.add_argument(
+    "--output-pdf-report",
+    default="vaccine-peptides-report.pdf",
+    help="Path to PDF vaccine peptide report")
 
 vaccine_peptide_group = arg_parser.add_argument_group("Vaccine peptide options")
 vaccine_peptide_group.add_argument(
@@ -120,13 +133,17 @@ def main(args_list=None):
 
     df.to_csv(args.output_csv, index=False)
 
-    ascii_report = ascii_report_from_ranked_vaccine_peptides(
+    make_ascii_report_from_ranked_vaccine_peptides(
         ranked_variants_with_vaccine_peptides=ranked_list,
         mhc_alleles=mhc_alleles,
         variants=variants,
-        bam_path=args.bam)
+        bam_path=args.bam,
+        ascii_report_path=args.output_ascii_report)
 
-    print(ascii_report)
-
-    with open(args.output_ascii_report, "w") as f:
-        f.write(ascii_report)
+    make_html_report_from_ranked_vaccine_peptides(
+        ranked_variants_with_vaccine_peptides=ranked_list,
+        mhc_alleles=mhc_alleles,
+        variants=variants,
+        bam_path=args.bam,
+        html_report_path=args.output_html_report,
+        pdf_report_path=args.output_pdf_report)

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -14,11 +14,23 @@
 
 from __future__ import absolute_import, print_function, division
 import logging
+import os
 
+import jinja2
+import pdfkit
 import roman
 
 
-def ascii_report_from_ranked_vaccine_peptides(
+JINJA_ENVIRONMENT = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),
+    extensions=['jinja2.ext.autoescape'],
+    autoescape=False,
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+def compute_template_data(
         ranked_variants_with_vaccine_peptides,
         mhc_alleles,
         variants,
@@ -29,16 +41,18 @@ def ascii_report_from_ranked_vaccine_peptides(
         for (variant, effect_collection)
         in variants.effects().drop_silent_and_noncoding().groupby_variant().items()
     }
-    lines = [
-        "VCF (somatic variants) path(s): %s" % "; ".join(variants.sources),
-        "BAM (RNAseq reads) path: %s" % bam_path,
-        "MHC alleles: %s" % (" ".join(mhc_alleles)),
-        "Total number of somatic variants: %d" % (len(variants),),
-        "Somatic variants with predicted coding effects: %d" % (
-            len(variants_to_top_coding_effect_dict),),
-        "---",
-    ]
 
+    template_data = {
+        'vcf_paths': "; ".join(variants.sources),
+        'bam_path': bam_path,
+        'mhc_alleles': " ".join(mhc_alleles),
+        'num_total_somatic_variants': len(variants),
+        'num_somatic_variants_with_predicted_coding_effects':
+            len(variants_to_top_coding_effect_dict),
+    }
+
+    # list ranked variants with their peptides
+    variants = []
     for i, (variant, vaccine_peptides) in enumerate(
             ranked_variants_with_vaccine_peptides):
         variant_short_description = variant.short_description
@@ -46,28 +60,24 @@ def ascii_report_from_ranked_vaccine_peptides(
             logging.info(
                 "Skipping %s, no vaccine peptides" % variant_short_description)
             continue
-
         gene_name = vaccine_peptides[0].mutant_protein_fragment.gene_name
-        lines.append("\n%d) %s (%s)" % (
-            i + 1,
-            variant_short_description,
-            gene_name,))
-        lines.append(
-            "\tTop score: %0.2f" % (vaccine_peptides[0].combined_score))
-        lines.append(
-            "\tPredicted effect: %s" % (
-                variants_to_top_coding_effect_dict.get(variant)))
-        lines.append(
-            "\tReads supporting variant allele: %d" % (
-                vaccine_peptides[0].mutant_protein_fragment.n_alt_reads))
-        lines.append(
-            "\tReads supporting reference allele: %d" % (
-                vaccine_peptides[0].mutant_protein_fragment.n_ref_reads))
-        lines.append(
-            "\tReads supporting other alleles: %d" % (
-                vaccine_peptides[0].mutant_protein_fragment.n_other_reads))
+        peptides = []
+        variant_dict = {
+            'num': i + 1,
+            'short_description': variant_short_description,
+            'gene_name': gene_name,
+            'top_score': vaccine_peptides[0].combined_score,
+            'predicted_effect': variants_to_top_coding_effect_dict.get(variant),
+            'reads_supporting_variant_allele':
+                vaccine_peptides[0].mutant_protein_fragment.n_alt_reads,
+            'reads_supporting_reference_allele':
+                vaccine_peptides[0].mutant_protein_fragment.n_ref_reads,
+            'reads_supporting_other_alleles':
+                vaccine_peptides[0].mutant_protein_fragment.n_other_reads,
+            'peptides': peptides,
+        }
 
-        lines.append("\tVaccine Peptides:")
+        # compile peptide info
         for j, vaccine_peptide in enumerate(vaccine_peptides):
             mutant_protein_fragment = vaccine_peptide.mutant_protein_fragment
             amino_acids = mutant_protein_fragment.amino_acids
@@ -76,37 +86,101 @@ def ascii_report_from_ranked_vaccine_peptides(
             aa_before_mutation = amino_acids[:mutation_start]
             aa_mutant = amino_acids[mutation_start:mutation_end]
             aa_after_mutation = amino_acids[mutation_end:]
-            lines.append("\t\t%s. %s_%s_%s (score = %0.2f)" % (
-                roman.toRoman(j + 1).lower(),
-                aa_before_mutation,
-                aa_mutant,
-                aa_after_mutation,
-                vaccine_peptide.combined_score))
-            lines.append(
-                "\t\t   - Length: %d" % len(amino_acids))
-            lines.append(
-                "\t\t   - Expression score: %0.2f" % (vaccine_peptide.expression_score))
-            lines.append(
-                "\t\t   - Mutant epitope score: %0.2f" % (
-                    vaccine_peptide.mutant_epitope_score))
-            lines.append(
-                "\t\t   - Wildtype epitope score: %0.2f" % (
-                    vaccine_peptide.wildtype_epitope_score))
-
-            lines.append(
-                "\t\t   - Reads fully spanning cDNA sequence(s): %d" % (
-                    mutant_protein_fragment.n_alt_reads_supporting_protein_sequence))
-            lines.append(
-                "\t\t   - Mutant amino acids: %d" % (
-                    mutant_protein_fragment.n_mutant_amino_acids))
-            lines.append(
-                "\t\t   - Mutation distance from edge: %d" % (
-                    mutant_protein_fragment.mutation_distance_from_edge))
-            lines.append("\t\t   - Predicted mutant epitopes:")
+            epitopes = []
+            peptide_dict = {
+                'num': roman.toRoman(j + 1).lower(),
+                'aa_before_mutation': aa_before_mutation,
+                'aa_mutant': aa_mutant,
+                'aa_after_mutation': aa_after_mutation,
+                'score': vaccine_peptide.combined_score,
+                'length': len(amino_acids),
+                'expression_score': vaccine_peptide.expression_score,
+                'mutant_epitope_score': vaccine_peptide.mutant_epitope_score,
+                'wildtype_epitope_score': vaccine_peptide.wildtype_epitope_score,
+                'num_alt_reads_supporting_protein_sequence':
+                    mutant_protein_fragment.n_alt_reads_supporting_protein_sequence,
+                'num_mutant_amino_acids':
+                    mutant_protein_fragment.n_mutant_amino_acids,
+                'mutation_distance_from_edge':
+                    mutant_protein_fragment.mutation_distance_from_edge,
+                'epitopes': epitopes,
+            }
+            
+            # compile epitope info
             for epitope_prediction in vaccine_peptide.epitope_predictions:
                 if epitope_prediction.overlaps_mutation and epitope_prediction.ic50 <= 2000:
-                    lines.append("\t\t\t * %s %0.2f (%s)" % (
-                        epitope_prediction.peptide_sequence,
-                        epitope_prediction.ic50,
-                        epitope_prediction.allele))
-    return "\n".join(lines)
+                    epitope_dict = {
+                        'sequence': epitope_prediction.peptide_sequence,
+                        'ic50': epitope_prediction.ic50,
+                        'allele': epitope_prediction.allele,
+                    }
+                    epitopes.append(epitope_dict)
+
+            peptides.append(peptide_dict)
+        variants.append(variant_dict)
+
+    template_data['variants'] = variants
+    return template_data
+
+
+def make_ascii_report_from_ranked_vaccine_peptides(
+        ranked_variants_with_vaccine_peptides,
+        mhc_alleles,
+        variants,
+        bam_path,
+        ascii_report_path):
+    template = JINJA_ENVIRONMENT.get_template('templates/template.txt')
+    template_data = compute_template_data(
+        ranked_variants_with_vaccine_peptides,
+        mhc_alleles,
+        variants,
+        bam_path)
+    report = template.render(template_data)
+    print(report)
+    with open(ascii_report_path, "w") as f:
+        f.write(report)
+
+
+# this is the hackiest thing in all the hacks. once we find out what the useful
+# vaxrank output formats are (will PDF be used? viewed? printed?, we can
+# fix this if necessary
+def compute_pdf_length_from_template_data(template_data):
+    length = 8  # 8" baseline from patient info header
+    variants = template_data['variants']
+    for variant in variants:
+        length += 6  # 6" space for variant description
+        for peptide in variant['peptides']:
+            length += 4  # 4" space for peptide description
+    return length
+
+
+def make_html_report_from_ranked_vaccine_peptides(
+        ranked_variants_with_vaccine_peptides,
+        mhc_alleles,
+        variants,
+        bam_path,
+        html_report_path,
+        pdf_report_path=None):
+    template = JINJA_ENVIRONMENT.get_template('templates/template.html')
+    template_data = compute_template_data(
+        ranked_variants_with_vaccine_peptides,
+        mhc_alleles,
+        variants,
+        bam_path)
+    with open(html_report_path, "w") as f:
+        f.write(template.render(template_data))
+
+    if pdf_report_path:
+        length_in_inches = compute_pdf_length_from_template_data(template_data)
+        # output to pdf
+        # note: these dimensions are bananas, and we'll need to fix the template
+        # if the goal is to have this report be printable on physical paper
+        options = {
+            'page-height': '%din' % length_in_inches,
+            'page-width': '13in'
+        }
+        pdfkit.from_file(html_report_path, pdf_report_path, options=options)
+
+
+
+

--- a/vaxrank/templates/stylesheet.css
+++ b/vaxrank/templates/stylesheet.css
@@ -1,0 +1,111 @@
+#main {
+	padding: 4em;
+}
+
+/* Various headers */
+#report-header {
+	padding-bottom: 1em;
+}
+
+#patient-info {
+	padding-bottom: 1em;
+}
+
+#variants {
+	padding-top: 1em;
+	padding-bottom: 1em;
+}
+
+#effects {
+	margin-bottom: 1.5em;
+}
+
+#peptides {
+	margin-bottom: 1.5em;
+}
+
+/* Variant list stuff */
+ol.main {
+	padding-left: 1.2em;
+	margin-left: 0.1em;
+	font-size: 2em;
+	color: #b3b3b3;
+}
+
+li.variant-list-item {
+	border-left: 0.3em solid;
+	padding: 0 2em 0 2em;
+	margin-bottom: 2em;
+}
+
+li.variant-list-item:nth-child(odd) {
+	border-left: 0.3em dotted;
+	padding: 0 2em 0 2em;
+	margin-bottom: 2em;
+}
+
+div.variant-span {
+	font-size: 16px;
+	color: black;
+}
+
+table.variant {
+	margin-top: -2em;
+	width: 90%;
+}
+
+col.variant-column-one {
+	width: 60%;
+}
+
+col.variant-column-two {
+	width: 40%;
+}
+
+thead.variant-head {
+	font-size: 135%;
+	margin-left: -2px;
+}
+
+td.variant-head {
+	padding-left: 0.7em;
+}
+
+/* Effects */
+table.effect {
+	width: 100%;
+	border: none;
+}
+
+td.effect {
+	padding: 0;
+}
+
+/* Peptides */
+ol.peptides {
+	padding-left: 0;
+	list-style-position: inside;
+}
+
+table.peptide {
+	margin: -1em 0 2em 2em;
+	width: 90%;
+}
+
+span.mutant {
+	background-color: yellow;
+	border: 1px;
+	border-style: solid;
+	border-color: red;
+	padding: 2px;
+	margin-left: 2px;
+	margin-right: 2px;
+}
+
+col.peptide-column-one {
+	width: 50%;
+}
+
+col.peptide-column-two {
+	width: 50%;
+}

--- a/vaxrank/templates/template.html
+++ b/vaxrank/templates/template.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Vaxrank Report</title>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+        <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/base-min.css">
+        <link rel="stylesheet" href="vaxrank/templates/stylesheet.css" type="text/css">
+    </head>
+    <body>
+    <div id="main">
+    	<h1 id="report-header">Vaccine Peptides Report</h1>
+    	<h3 id="patient-info">PATIENT INFO</h3>
+    	<table class="pure-table pure-table-bordered patient-info">
+    		<tr>
+    			<td>VCF (somatic variants) path(s)</td>
+    			<td>{{ vcf_paths }}</td>
+    		</tr>
+    		<tr>
+    			<td>BAM (RNAseq reads) path</td>
+    			<td>{{ bam_path }}</td>
+    		</tr>
+    		<tr>
+    			<td>MHC alleles</td>
+    			<td>{{ mhc_alleles }}</td>
+    		</tr>
+    		<tr>
+    			<td>Total number of somatic variants</td>
+    			<td>{{ num_total_somatic_variants }}</td>
+    		</tr>
+    		<tr>
+    			<td>Somatic variants with predicted coding effects</td>
+    			<td>{{ num_somatic_variants_with_predicted_coding_effects }}</td>
+    		</tr>
+    	</table>
+    	<br>
+    	<h3 id="variants">VARIANTS</h3>
+    	<ol class="main">
+    	{% for v in variants %}
+    	<li class="variant-list-item">
+            <div class="variant-span">
+    		<table class="pure-table pure-table-bordered variant">
+    			<colgroup>
+                	<col class="variant-column-one">
+                    <col class="variant-column-two">
+                </colgroup>
+                <thead class="variant-head">
+                    <tr>
+                        <td class="variant-head">Variant</td>
+                        <td class="variant-head">{{ v.short_description }}</td>
+                    </tr>
+                </thead>
+                <tr>
+                    <td>Gene name</td>
+                    <td>{{ v.gene_name }}</td>
+                </tr>
+                <tr>
+                    <td>Top score</td>
+                    <td>{{ v.top_score|round(2) }}</td>
+                </tr>
+                <tr>
+                    <td>Reads supporting variant allele</td>
+                    <td>{{ v.reads_supporting_variant_allele }}</td>
+                </tr>
+                <tr>
+                    <td>Reads supporting reference allele</td>
+                    <td>{{ v.reads_supporting_reference_allele }}</td>
+                </tr>
+                <tr>
+                    <td>Reads supporting other alleles</td>
+                    <td>{{ v.reads_supporting_other_alleles }}</td>
+                </tr>
+            </table>
+            <br>
+            <h4 id="effects">Predicted Effect</h4>
+            <table class="pure-table pure-table-bordered">
+        		<tr>
+        			<td>Effect type</td>
+        			<td>{{ v.predicted_effect.__class__.__name__ }}</td>
+        		</tr>
+        		<tr>
+        			<td>Transcript name</td>
+        			<td>{{ v.predicted_effect.transcript_name }}</td>
+        		</tr>
+        		<tr>
+        			<td>Transcript ID</td>
+        			<td>{{ v.predicted_effect.transcript_id }}</td>
+        		</tr>
+        		<tr>
+        			<td>Effect description</td>
+        			<td>{{ v.predicted_effect.short_description }}</td>
+        		</tr>
+        	</table>
+        	<br>
+    		<h4 id="peptides">Vaccine Peptides for variant: {{ v.short_description }}</h4>
+    		<ol class="peptides" type="i">
+    			{% for p in v.peptides %}
+    			<li>
+    				<table class="pure-table pure-table-bordered peptide">
+    					<colgroup>
+		                	<col class="peptide-column-one">
+		                    <col class="peptide-column-two">
+		                </colgroup>
+    					<thead>
+                    		<tr>
+                        		<td>Amino acid sequence</td>
+		                        <td>{{ p.aa_before_mutation }}<span class="mutant">{{ p.aa_mutant }}</span>{{ p.aa_after_mutation }}</td>
+        	            	</tr>
+            		    </thead>
+            		    <tr>
+		        			<td>Transcript name</td>
+		        			<td>{{ v.predicted_effect.transcript_name }}</td>
+		        		</tr>
+            		    <tr>
+        	            	<td>Length</td>
+        	            	<td>{{ p.length }}</td>
+        	            </tr>
+        	            <tr>
+        	            	<td>Expression score</td>
+        	            	<td>{{ p.expression_score|round(2) }}</td>
+        	            </tr>
+        	            <tr>
+        	            	<td>Mutant epitope score</td>
+        	            	<td>{{ p.mutant_epitope_score|round(2) }}</td>
+        	            </tr>
+        	            <tr>
+        	            	<td>Reads fully spanning cDNA sequence(s)</td>
+        	            	<td>{{ p.num_alt_reads_supporting_protein_sequence }}</td>
+        	            </tr>
+        	            <tr>
+        	            	<td>Mutant amino acids</td>
+        	            	<td>{{ p.num_mutant_amino_acids }}</td>
+        	            </tr>
+        	            <tr>
+        	            	<td>Mutation distance from edge</td>
+        	            	<td>{{ p.mutation_distance_from_edge }}</td>
+        	            </tr>
+        	            <tr>
+        	            	<td>Predicted mutant epitopes</td>
+        	            	<td class="effect">
+                    			<table class="pure-table effect">
+                    				<thead>
+                    					<tr>
+			                        		<td>Sequence</td>
+					                        <td>IC50</td>
+					                        <td>Allele</td>
+			        	            	</tr>
+			            		    </thead>
+			            		    {% for e in p.epitopes %}
+		                    		<tr>
+        		            			<td>{{ e.sequence }}</td>
+        		            			<td>{{ e.ic50|round(2) }}</td>
+        		            			<td>{{ e.allele }}</td>
+		                    		</tr>
+		                    		{% endfor %}
+        		            	</table>
+		                    </td>
+        	            </tr>
+    				</table>
+    			</li>
+    			{% endfor %}
+    		</ol>
+            </div>
+    	</li>
+    	{% endfor %}
+    	</ol>
+    </div>
+    </body>
+</html>

--- a/vaxrank/templates/template.html
+++ b/vaxrank/templates/template.html
@@ -5,7 +5,9 @@
         <meta charset="UTF-8">
         <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
         <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/base-min.css">
-        <link rel="stylesheet" href="vaxrank/templates/stylesheet.css" type="text/css">
+        <style type="text/css">
+            {% include "templates/stylesheet.css" %}
+        </style>
     </head>
     <body>
     <div id="main">

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -1,0 +1,31 @@
+VCF (somatic variants) path(s): {{ vcf_paths }}
+BAM (RNAseq reads) path: {{ bam_path }}
+MHC alleles: {{ mhc_alleles }}
+Total number of somatic variants: {{ num_total_somatic_variants }}
+Somatic variants with predicted coding effects: {{ num_somatic_variants_with_predicted_coding_effects }}
+---
+
+{% for v in variants %}
+{{ v.num }}) {{ v.short_description }} ({{ v.gene_name }})
+        Top score: {{ v.top_score|round(2) }}
+        Predicted effect: {{ v.predicted_effect }}
+        Reads supporting variant allele: {{ v.reads_supporting_variant_allele }}
+        Reads supporting reference allele: {{ v.reads_supporting_reference_allele }}
+        Reads supporting other alleles: {{ v.reads_supporting_other_alleles }}
+        Vaccine Peptides:
+        {% for p in v.peptides %}
+                {{ p.num }}. {{ p.aa_before_mutation }}_{{ p.aa_mutant }}_{{ p.aa_after_mutation }} (score = {{ p.score|round(2) }})
+                   - Length: {{ p.length }}
+                   - Expression score: {{ p.expression_score|round(2) }}
+                   - Mutant epitope score: {{ p.mutant_epitope_score|round(2) }}
+                   - Wildtype epitope score: {{ p.wildtype_epitope_score|round(2) }}
+                   - Reads fully spanning cDNA sequence(s): {{ p.num_alt_reads_supporting_protein_sequence }}
+                   - Mutant amino acids: {{ p.num_mutant_amino_acids }}
+                   - Mutation distance from edge: {{ p.mutation_distance_from_edge }}
+                   - Predicted mutant epitopes:
+                   {% for e in p.epitopes %}
+                         * {{ e.sequence }} {{ e.ic50|round(2) }} ({{ e.allele }})
+                   {% endfor %}
+
+        {% endfor %}
+{% endfor %}


### PR DESCRIPTION
- refactored report generation to create a dictionary of values which then gets fed into ASCII/HTML/whatever template
- added an HTML template and an ASCII template that's very close to previous output (only difference should be whitespace)
- added report outputs to .gitignore
- updated some requirements files

Fixes #3 - also see PDF for what this looks like

[vaccine-peptides-report.pdf](https://github.com/hammerlab/vaxrank/files/488144/vaccine-peptides-report.pdf)
