### PR TITLE
A bunch of vaxrank report changes

### DIFF
--- a/run-vaxrank-b16-test-data.sh
+++ b/run-vaxrank-b16-test-data.sh
@@ -5,4 +5,10 @@ vaxrank \
     --mhc-predictor netmhc \
     --mhc-alleles H2-Kb,H2-Db \
     --padding-around-mutation 5 \
-    --output-ascii-report vaccine-peptides-report.txt
+    --output-ascii-report vaccine-peptides-report.txt \
+    --output-html-report vaccine-peptides-report.html \
+    --output-pdf-report vaccine-peptides-report.pdf \
+    --output-pickle-file report.pkl \
+    --output-reviewed-by "John Doe,Jane Doe" \
+    --output-final-review "All the Does" \
+    --output-patient-id "Namey McName"

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -187,7 +187,10 @@ def load_template_data(args):
         'reviewers': args.output_reviewed_by.split(','),
         })
 
-    # save pickled template data if necessary
+    # save pickled template data if necessary. this is meant to make a dev's life easier:
+    # as of time of writing, vaxrank takes ~25 min to run, most of which is core logic
+    # that creates the template_data dictionary. the formatting is super fast, and it can
+    # be useful to save template_data to be able to iterate just on the formatting.
     if args.output_pickle_file:
         with open(args.output_pickle_file, 'wb') as f:
             pickle.dump(template_data, f)

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, print_function, division
 import sys
 import logging
 import logging.config
+import pickle
 import pkg_resources
 
 from varcode.cli import variant_collection_from_args
@@ -51,6 +52,11 @@ arg_parser = make_variant_sequences_arg_parser(
 add_mhc_args(arg_parser)
 
 arg_parser.add_argument(
+    "--output-patient-id",
+    default="",
+    help="Patient ID to use in report")
+
+arg_parser.add_argument(
     "--output-csv",
     default="",
     help="Name of CSV file which contains predicted sequences")
@@ -69,6 +75,27 @@ arg_parser.add_argument(
     "--output-pdf-report",
     default="",
     help="Path to PDF vaccine peptide report")
+
+arg_parser.add_argument(
+    "--output-pickle-file",
+    default="",
+    help="Path to output pickle file containing report template data")
+
+arg_parser.add_argument(
+    "--input-pickle-file",
+    default="",
+    help="Path to input pickle file containing report template data. "
+    "If present, other report-relevant options will be ignored.")
+
+arg_parser.add_argument(
+    "--output-reviewed-by",
+    default="",
+    help="Comma-separated list of reviewer names")
+
+arg_parser.add_argument(
+    "--output-final-review",
+    default="",
+    help="Name of final reviewer of report")
 
 vaccine_peptide_group = arg_parser.add_argument_group("Vaccine peptide options")
 vaccine_peptide_group.add_argument(
@@ -98,34 +125,28 @@ vaccine_peptide_group.add_argument(
     type=int,
     help="Number of mutations to report")
 
-def main(args_list=None):
-    """
-    Script to generate vaccine peptide predictions from somatic cancer variants,
-    patient HLA type, and tumor RNA-seq data.
 
-    Example usage:
-        vaxrank
-            --vcf somatic.vcf \
-            --bam rnaseq.bam \
-            --vaccine-peptide-length 25 \
-            --output-csv vaccine-peptides.csv
-    """
-    if args_list is None:
-        args_list = sys.argv[1:]
+def load_template_data(args):
+    if args.input_pickle_file:
+        f = open(args.input_pickle_file, 'rb')
+        template_data = pickle.load(f)
+        f.close()
+        logger.info('Loaded pickled template data from %s', args.input_pickle_file)
+        # set the template data input_pickle_file arg; all other args remain unchanged
+        # since we want the displayed args to reflect what was previously pickled
+        arg_list = template_data['args']
+        index = [i for i, x in enumerate(arg_list) if x[0] == 'input_pickle_file'][0]
+        arg_list[index] = ('input_pickle_file', args.input_pickle_file)
+        return template_data
 
+    interesting_args = []
+    for key, value in sorted(vars(args).items()):
+        if not key.startswith('output'):
+            interesting_args.append((key, value))
 
-    args = arg_parser.parse_args(args_list)
-    logger.info(args)
-
-    if (len(args.output_csv) == 0 and
-            len(args.output_ascii_report) == 0 and
-            len(args.output_html_report) == 0 and
-            len(args.output_pdf_report) == 0):
-        raise ValueError(
-            "Must specify at least one of: --output-csv, "
-            "--output-ascii-report, "
-            "--output-html-report, "
-            "--output-pdf-report")
+    if len(args.output_patient_id) == 0:
+        logger.warn("Please specify --output-patient-id; defaulting to unknown")
+        args.output_patient_id = "UNKNOWN"
 
     variants = variant_collection_from_args(args)
     logger.info(variants)
@@ -158,6 +179,52 @@ def main(args_list=None):
         mhc_alleles=mhc_alleles,
         variants=variants,
         bam_path=args.bam)
+
+    template_data.update({
+        'args': interesting_args,
+        'patient_id': args.output_patient_id,
+        'final_review': args.output_final_review,
+        'reviewers': args.output_reviewed_by.split(','),
+        })
+
+    # save pickled template data if necessary
+    if args.output_pickle_file:
+        with open(args.output_pickle_file, 'wb') as f:
+            pickle.dump(template_data, f)
+        logger.info('Wrote pickled template data to %s', args.output_pickle_file)
+
+    return template_data
+
+
+def main(args_list=None):
+    """
+    Script to generate vaccine peptide predictions from somatic cancer variants,
+    patient HLA type, and tumor RNA-seq data.
+
+    Example usage:
+        vaxrank
+            --vcf somatic.vcf \
+            --bam rnaseq.bam \
+            --vaccine-peptide-length 25 \
+            --output-csv vaccine-peptides.csv
+    """
+    if args_list is None:
+        args_list = sys.argv[1:]
+
+    args = arg_parser.parse_args(args_list)
+    logger.info(vars(args))
+
+    if (len(args.output_csv) == 0 and
+            len(args.output_ascii_report) == 0 and
+            len(args.output_html_report) == 0 and
+            len(args.output_pdf_report) == 0):
+        raise ValueError(
+            "Must specify at least one of: --output-csv, "
+            "--output-ascii-report, "
+            "--output-html-report, "
+            "--output-pdf-report")
+
+    template_data = load_template_data(args)
 
     if args.output_ascii_report:
         make_ascii_report(

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -174,8 +174,8 @@ def make_pdf_report(
         # note: these dimensions are bananas, and we'll need to fix the template
         # if the goal is to have this report be printable on physical paper
         options = {
-            'page-height': '%din' % length_in_inches,
-            'page-width': '13in'
+            'zoom': 0.6,
+            'margin-top': '20mm'
         }
         pdfkit.from_file(f.name, pdf_report_path, options=options)
     logger.info('Wrote PDF report to %s', pdf_report_path)

--- a/vaxrank/templates/stylesheet.css
+++ b/vaxrank/templates/stylesheet.css
@@ -24,6 +24,37 @@
 	margin-bottom: 1.5em;
 }
 
+#args {
+	padding-top: 2em;
+	padding-bottom: 1em;
+}
+
+/* Patient info */
+table.patient-info {
+	width: 90%;
+}
+
+col.patient-info-column-one {
+	width: 40%;
+}
+
+col.patient-info-column-two {
+
+}
+
+/* Command-line args */
+table.args {
+	width: 90%;
+}
+
+col.args-column-one {
+	width: 40%;
+}
+
+col.args-column-two {
+
+}
+
 /* Variant list stuff */
 ol.main {
 	padding-left: 1.2em;
@@ -36,12 +67,16 @@ li.variant-list-item {
 	border-left: 0.3em solid;
 	padding: 0 2em 0 2em;
 	margin-bottom: 2em;
+	page-break-before: always;
+	page-break-after: always;
 }
 
 li.variant-list-item:nth-child(odd) {
 	border-left: 0.3em dotted;
 	padding: 0 2em 0 2em;
 	margin-bottom: 2em;
+	page-break-before: always;
+	page-break-after: always;
 }
 
 div.variant-span {
@@ -87,6 +122,10 @@ ol.peptides {
 	list-style-position: inside;
 }
 
+li.peptide {
+	page-break-inside: avoid;
+}
+
 table.peptide {
 	margin: -1em 0 2em 2em;
 	width: 90%;
@@ -108,4 +147,26 @@ col.peptide-column-one {
 
 col.peptide-column-two {
 	width: 50%;
+}
+
+/* Signatures */
+table.signature {
+	width: 70%;
+}
+
+table.signature-inner {
+	width: 100%;
+	border: none;
+}
+
+td.signature-inner {
+	padding: 0;
+}
+
+col.signature-column-one {
+	width: 30%;
+}
+
+col.signature-column-two {
+	width: 70%;
 }

--- a/vaxrank/templates/template.html
+++ b/vaxrank/templates/template.html
@@ -14,7 +14,15 @@
     	<h1 id="report-header">Vaccine Peptides Report</h1>
     	<h3 id="patient-info">PATIENT INFO</h3>
     	<table class="pure-table pure-table-bordered patient-info">
+            <colgroup>
+                <col class="patient-info-column-one">
+                <col class="patient-info-column-two">
+            </colgroup>
     		<tr>
+                <td>Patient ID</td>
+                <td>{{ patient_id }}</td>
+            </tr>
+            <tr>
     			<td>VCF (somatic variants) path(s)</td>
     			<td>{{ vcf_paths }}</td>
     		</tr>
@@ -36,7 +44,19 @@
     		</tr>
     	</table>
     	<br>
-    	<h3 id="variants">VARIANTS</h3>
+        <h3 id="args">COMMAND LINE ARGUMENTS</h4>
+        <table class="pure-table pure-table-bordered args">
+            <colgroup>
+                <col class="args-column-one">
+                <col class="args-column-two">
+            </colgroup>
+            {% for a in args %}
+            <tr>
+                <td class="arg">{{ a[0] }}</td>
+                <td class="arg">{{ a[1] }}</td>
+            </tr>
+            {% endfor %}
+        </table>
     	<ol class="main">
     	{% for v in variants %}
     	<li class="variant-list-item">
@@ -97,7 +117,7 @@
     		<h4 id="peptides">Vaccine Peptides for variant: {{ v.short_description }}</h4>
     		<ol class="peptides" type="i">
     			{% for p in v.peptides %}
-    			<li>
+    			<li class="peptide">
     				<table class="pure-table pure-table-bordered peptide">
     					<colgroup>
 		                	<col class="peptide-column-one">
@@ -166,6 +186,42 @@
     	</li>
     	{% endfor %}
     	</ol>
+        <table class="pure-table pure-table-bordered reviewed-by">
+            <thead>
+                <tr><td>Reviewed By</td></tr>
+            </thead>
+            {% for r in reviewers %}
+            <tr><td>{{ r }}</td></tr>
+            {% endfor %}
+        </table>
+        <br><br>
+        <table class="pure-table pure-table-bordered signature">
+            <thead>
+                <tr><td>Final Review</td></tr>
+            </thead>
+            <tr>
+                <td class="signature-inner">
+                    <table class="pure-table signature-inner">
+                        <colgroup>
+                            <col class="signature-column-one">
+                            <col class="signature-column-two">
+                        </colgroup>
+                        <tr>
+                            <td>Name</td>
+                            <td>{{ final_review }}</td>
+                        </tr>
+                        <tr>
+                            <td>Signature</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td>Date</td>
+                            <td></td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
     </div>
     </body>
 </html>


### PR DESCRIPTION
- sane page sizes and breaks in PDF: should now be printable
- adding a reviewer list/signature section to end of report
- adding command-line arg list to start of report
- adding ability to locally save/load pickled template data
- refactoring cli.py a bit to make it neater to load template data from pickle
- adding CLI args for patient ID (defaults to “UNKNOWN” if not passed in), input/output pickle files, report reviewer names
- outputting ascii/html/pdf/pickle file in test script

Fixes #42, #43, #45, #53 

See resulting mouse melanoma report here:
[real.pdf](https://github.com/hammerlab/vaxrank/files/532425/real.pdf)
