### PR TITLE
Refactor report ordered dict

### DIFF
--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -30,10 +30,10 @@ from isovar.cli.rna_reads import allele_reads_generator_from_args
 
 from .core_logic import ranked_vaccine_peptides, dataframe_from_ranked_list
 from .report import (
-    compute_template_data,
     make_ascii_report,
     make_html_report,
     make_pdf_report,
+    TemplateDataCreator,
 )
 
 
@@ -203,12 +203,14 @@ def load_template_data(args):
         'reviewers': args.output_reviewed_by.split(','),
     }
 
-    template_data = compute_template_data(
+    template_data_creator = TemplateDataCreator(
         ranked_variants_with_vaccine_peptides=ranked_list_for_report,
         mhc_alleles=mhc_alleles,
         variants=variants,
         bam_path=args.bam,
         output_values=output_values)
+
+    template_data = template_data_creator.compute_template_data()
 
     # save pickled template data if necessary. this is meant to make a dev's life easier:
     # as of time of writing, vaxrank takes ~25 min to run, most of which is core logic

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -196,18 +196,19 @@ def load_template_data(args):
     if args.output_csv:
         df.to_csv(args.output_csv, index=False)
 
-    template_data = compute_template_data(
-        ranked_variants_with_vaccine_peptides=ranked_list_for_report,
-        mhc_alleles=mhc_alleles,
-        variants=variants,
-        bam_path=args.bam)
-
-    template_data.update({
+    output_values = {
         'args': interesting_args,
         'patient_id': args.output_patient_id,
         'final_review': args.output_final_review,
         'reviewers': args.output_reviewed_by.split(','),
-    })
+    }
+
+    template_data = compute_template_data(
+        ranked_variants_with_vaccine_peptides=ranked_list_for_report,
+        mhc_alleles=mhc_alleles,
+        variants=variants,
+        bam_path=args.bam,
+        output_values=output_values)
 
     # save pickled template data if necessary. this is meant to make a dev's life easier:
     # as of time of writing, vaxrank takes ~25 min to run, most of which is core logic

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -35,143 +35,210 @@ JINJA_ENVIRONMENT = jinja2.Environment(
 )
 
 
-def compute_template_data(
-        ranked_variants_with_vaccine_peptides,
-        mhc_alleles,
-        variants,
-        bam_path,
-        output_values):
-    # create dictionary mapping variants to coding effects
-    variants_to_top_coding_effect_dict = {
-        variant: effect_collection.top_priority_effect()
-        for (variant, effect_collection)
-        in variants.effects().drop_silent_and_noncoding().groupby_variant().items()
-    }
+class TemplateDataCreator(object):
+    def __init__(
+            self,
+            ranked_variants_with_vaccine_peptides,
+            mhc_alleles,
+            variants,
+            bam_path,
+            output_values):
+        """
+        Construct a TemplateDataCreator object, from the output of the vaxrank pipeline.
+        """
+        self.ranked_variants_with_vaccine_peptides = ranked_variants_with_vaccine_peptides
+        self.mhc_alleles = mhc_alleles
+        self.variants = variants
+        self.bam_path = bam_path
+        self.output_values = output_values
 
-    ############################### Patient info ###############################
-
-    patient_info = OrderedDict()
-    patient_info['Patient ID'] = output_values['patient_id']
-    patient_info['VCF (somatic variants) path(s)'] = "; ".join(variants.sources)
-    patient_info['BAM (RNAseq reads) path'] = bam_path
-    patient_info['MHC alleles'] = " ".join(mhc_alleles)
-    patient_info['Total number of somatic variants'] = len(variants)
-    patient_info['Somatic variants with predicted coding effects'] = len(
-        variants_to_top_coding_effect_dict)
-
-    # list ranked variants with their peptides
-    variants = []
-    for i, (variant, vaccine_peptides) in enumerate(
-            ranked_variants_with_vaccine_peptides):
-        variant_short_description = variant.short_description
-        if len(vaccine_peptides) == 0:
-            logger.info("Skipping %s, no vaccine peptides", variant_short_description)
-            continue
-
-        ############################### Variant info ###############################
-
-        variant_data = OrderedDict()
-        mutant_protein_fragment = vaccine_peptides[0].mutant_protein_fragment
-        top_score = round(vaccine_peptides[0].combined_score, 4)
-        variant_data['Gene name'] = mutant_protein_fragment.gene_name
-        variant_data['Top score'] = top_score
-        variant_data['Reads supporting variant allele'] = mutant_protein_fragment.n_alt_reads
-        variant_data['Reads supporting reference allele'] = mutant_protein_fragment.n_ref_reads
-        variant_data['Reads supporting other alleles'] = mutant_protein_fragment.n_other_reads
-
-        ############################### Predicted effect info ###############################
-
-        predicted_effect = variants_to_top_coding_effect_dict.get(variant)
-        effect_data = OrderedDict()
-        effect_data['Effect type'] = predicted_effect.__class__.__name__
-        effect_data['Transcript name'] = predicted_effect.transcript_name
-        effect_data['Transcript ID'] = predicted_effect.transcript_id
-        effect_data['Effect description'] = predicted_effect.short_description
-
-        peptides = []
-        for j, vaccine_peptide in enumerate(vaccine_peptides):
-            mutant_protein_fragment = vaccine_peptide.mutant_protein_fragment
-            amino_acids = mutant_protein_fragment.amino_acids
-            mutation_start = mutant_protein_fragment.mutant_amino_acid_start_offset
-            mutation_end = mutant_protein_fragment.mutant_amino_acid_end_offset
-            aa_before_mutation = amino_acids[:mutation_start]
-            aa_mutant = amino_acids[mutation_start:mutation_end]
-            aa_after_mutation = amino_acids[mutation_end:]
-
-            header_display_data = {
-                'num': roman.toRoman(j + 1).lower(),
-                'aa_before_mutation': aa_before_mutation,
-                'aa_mutant': aa_mutant,
-                'aa_after_mutation': aa_after_mutation,
-            }
-
-            ############################### Peptide info ###############################
-
-            peptide_data = OrderedDict()
-            peptide_data['Transcript name'] = predicted_effect.transcript_name
-            peptide_data['Length'] = len(amino_acids)
-            peptide_data['Expression score'] = round(vaccine_peptide.expression_score, 4)
-            peptide_data['Mutant epitope score'] = round(vaccine_peptide.mutant_epitope_score, 4)
-            peptide_data['Combined score'] = round(vaccine_peptide.combined_score, 4)
-            peptide_data['Reads fully spanning cDNA sequence(s)'] = \
-                mutant_protein_fragment.n_alt_reads_supporting_protein_sequence
-            peptide_data['Mutant amino acids'] = mutant_protein_fragment.n_mutant_amino_acids
-            peptide_data['Mutation distance from edge'] = \
-                mutant_protein_fragment.mutation_distance_from_edge
-
-            ############################### Manufacturability info ###############################
-            
-            manufacturability_data = OrderedDict()
-            scores = vaccine_peptide.manufacturability_scores
-            manufacturability_data['C-terminal 7mer GRAVY score'] = \
-                    round(scores.cterm_7mer_gravy_score, 4)
-            manufacturability_data['Max 7mer GRAVY score'] = round(scores.max_7mer_gravy_score, 4)
-            manufacturability_data['N-terminal Glutamine, Glutamic Acid, or Cysteine'] = int(
-                scores.difficult_n_terminal_residue)
-            manufacturability_data['C-terminal Cysteine'] = int(
-                scores.c_terminal_cysteine)
-            manufacturability_data['C-terminal Proline'] = int(scores.c_terminal_proline)
-            manufacturability_data['Total number of Cysteine residues'] = scores.cysteine_count
-            manufacturability_data['N-terminal Asparagine'] = int(scores.n_terminal_asparagine)
-            manufacturability_data['Number of Asparagine-Proline bonds'] = \
-                scores.asparagine_proline_bond_count
-            
-            ############################### Epitopes info ###############################
-
-            epitopes = []
-            for epitope_prediction in vaccine_peptide.epitope_predictions:
-                if epitope_prediction.overlaps_mutation:
-                    epitope_data = OrderedDict()
-                    epitope_data['Sequence'] = epitope_prediction.peptide_sequence
-                    epitope_data['IC50'] = epitope_prediction.ic50
-                    epitope_data['Normalized binding score'] = round(
-                        epitope_prediction.logistic_score(), 4)
-                    epitope_data['Allele'] = epitope_prediction.allele
-                    epitopes.append(epitope_data)
-
-            peptide_dict = {
-                'header_display_data': header_display_data,
-                'peptide_data': peptide_data,
-                'manufacturability_data': manufacturability_data,
-                'epitopes': epitopes,
-            }
-            peptides.append(peptide_dict)
-
-        variant_dict = {
-            'num': i + 1,
-            'short_description': variant_short_description,
-            'variant_data': variant_data,
-            'effect_data': effect_data,
-            'peptides': peptides,
+        # create dictionary mapping variants to coding effects
+        self.variants_to_top_coding_effect_dict = {
+            variant: effect_collection.top_priority_effect()
+            for (variant, effect_collection)
+            in self.variants.effects().drop_silent_and_noncoding().groupby_variant().items()
         }
-        variants.append(variant_dict)
 
-    template_data = {
-        'patient_info': patient_info,
-        'variants': variants,
-    }
-    template_data.update(output_values)
-    return template_data
+    def _patient_info(self):
+        """
+        Returns an OrderedDict with patient info.
+        """
+        patient_info = OrderedDict([
+            ('Patient ID', self.output_values['patient_id']),
+            ('VCF (somatic variants) path(s)', '; '.join(self.variants.sources)),
+            ('BAM (RNAseq reads) path', self.bam_path),
+            ('MHC alleles', ' '.join(self.mhc_alleles)),
+            ('Total number of somatic variants', len(self.variants)),
+            ('Somatic variants with predicted coding effects',
+                len(self.variants_to_top_coding_effect_dict)),
+        ])
+        return patient_info
+
+    def _variant_data(self, top_vaccine_peptide):
+        """
+        Returns an OrderedDict with info used to populate variant info section.
+        """
+        variant_data = OrderedDict()
+        mutant_protein_fragment = top_vaccine_peptide.mutant_protein_fragment
+        top_score = round(top_vaccine_peptide.combined_score, 4)
+        variant_data = OrderedDict([
+            ('Gene name', mutant_protein_fragment.gene_name),
+            ('Top score', top_score),
+            ('Reads supporting variant allele', mutant_protein_fragment.n_alt_reads),
+            ('Reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
+            ('Reads supporting other alleles', mutant_protein_fragment.n_other_reads),
+        ])
+        return variant_data
+
+    def _effect_data(self, predicted_effect):
+        """
+        Returns an OrderedDict with info about the given predicted effect.
+        """
+        effect_data = OrderedDict([
+            ('Effect type', predicted_effect.__class__.__name__),
+            ('Transcript name',predicted_effect.transcript_name),
+            ('Transcript ID', predicted_effect.transcript_id),
+            ('Effect description', predicted_effect.short_description),
+        ])
+        return effect_data
+
+    def _peptide_header_display_data(self, vaccine_peptide, rank):
+        """
+        Returns a dictionary with info used to populate the header section of a peptide table.
+
+        Parameters
+        ----------
+        vaccine_peptide : VaccinePeptide
+          The given peptide to convert to display form
+
+        rank : int
+          Rank of vaccine peptide in list
+        """
+        mutant_protein_fragment = vaccine_peptide.mutant_protein_fragment
+        amino_acids = mutant_protein_fragment.amino_acids
+        mutation_start = mutant_protein_fragment.mutant_amino_acid_start_offset
+        mutation_end = mutant_protein_fragment.mutant_amino_acid_end_offset
+        aa_before_mutation = amino_acids[:mutation_start]
+        aa_mutant = amino_acids[mutation_start:mutation_end]
+        aa_after_mutation = amino_acids[mutation_end:]
+
+        header_display_data = {
+            'num': roman.toRoman(rank + 1).lower(),
+            'aa_before_mutation': aa_before_mutation,
+            'aa_mutant': aa_mutant,
+            'aa_after_mutation': aa_after_mutation,
+        }
+        return header_display_data
+
+    def _peptide_data(self, vaccine_peptide, transcript_name):
+        """
+        Returns a dictionary with info used to populate peptide table contents.
+
+        Parameters
+        ----------
+        vaccine_peptide : VaccinePeptide
+          The given peptide to convert to display form
+
+        transcript_name : str
+            RNA transcript name (should match that displayed in effect section)
+        """
+        mutant_protein_fragment = vaccine_peptide.mutant_protein_fragment
+        amino_acids = mutant_protein_fragment.amino_acids
+        peptide_data = OrderedDict([
+            ('Transcript name', transcript_name),
+            ('Length', len(amino_acids)),
+            ('Expression score', round(vaccine_peptide.expression_score, 4)),
+            ('Mutant epitope score', round(vaccine_peptide.mutant_epitope_score, 4)),
+            ('Combined score', round(vaccine_peptide.combined_score, 4)),
+            ('Reads fully spanning cDNA sequence(s)',
+                mutant_protein_fragment.n_alt_reads_supporting_protein_sequence),
+            ('Mutant amino acids', mutant_protein_fragment.n_mutant_amino_acids),
+            ('Mutation distance from edge',
+                mutant_protein_fragment.mutation_distance_from_edge),
+        ])
+        return peptide_data
+
+    def _manufacturability_data(self, vaccine_peptide):
+        """
+        Returns an OrderedDict with manufacturability data for the given peptide.
+        """
+        scores = vaccine_peptide.manufacturability_scores
+        manufacturability_data = OrderedDict([
+            ('C-terminal 7mer GRAVY score', round(scores.cterm_7mer_gravy_score, 4)),
+            ('Max 7mer GRAVY score', round(scores.max_7mer_gravy_score, 4)),
+            ('N-terminal Glutamine, Glutamic Acid, or Cysteine',
+                int(scores.difficult_n_terminal_residue)),
+            ('C-terminal Cysteine', int(scores.c_terminal_cysteine)),
+            ('C-terminal Proline', int(scores.c_terminal_proline)),
+            ('Total number of Cysteine residues', scores.cysteine_count),
+            ('N-terminal Asparagine', int(scores.n_terminal_asparagine)),
+            ('Number of Asparagine-Proline bonds', scores.asparagine_proline_bond_count),
+        ])
+        return manufacturability_data
+
+    def _epitope_data(self, epitope_prediction):
+        """
+        Returns an OrderedDict with epitope data from the given prediction.
+        """
+        epitope_data = OrderedDict([
+            ('Sequence', epitope_prediction.peptide_sequence),
+            ('IC50', epitope_prediction.ic50),
+            ('Normalized binding score', round(epitope_prediction.logistic_score(), 4)),
+            ('Allele', epitope_prediction.allele),
+        ])
+        return epitope_data
+
+    def compute_template_data(self):
+        patient_info = self._patient_info()
+
+        # list ranked variants with their peptides
+        variants = []
+        for i, (variant, vaccine_peptides) in enumerate(
+                self.ranked_variants_with_vaccine_peptides):
+            variant_short_description = variant.short_description
+            if len(vaccine_peptides) == 0:
+                logger.info("Skipping %s, no vaccine peptides", variant_short_description)
+                continue
+
+            variant_data = self._variant_data(vaccine_peptides[0])
+            predicted_effect = self.variants_to_top_coding_effect_dict.get(variant)
+            effect_data = self._effect_data(predicted_effect)
+
+            peptides = []
+            for j, vaccine_peptide in enumerate(vaccine_peptides):
+                header_display_data = self._peptide_header_display_data(vaccine_peptide, j)
+                peptide_data = self._peptide_data(vaccine_peptide, predicted_effect.transcript_name)
+                manufacturability_data = self._manufacturability_data(vaccine_peptide)
+
+                epitopes = []
+                for epitope_prediction in vaccine_peptide.epitope_predictions:
+                    if epitope_prediction.overlaps_mutation:
+                        epitope_data = self._epitope_data(epitope_prediction)
+                        epitopes.append(epitope_data)
+
+                peptide_dict = {
+                    'header_display_data': header_display_data,
+                    'peptide_data': peptide_data,
+                    'manufacturability_data': manufacturability_data,
+                    'epitopes': epitopes,
+                }
+                peptides.append(peptide_dict)
+
+            variant_dict = {
+                'num': i + 1,
+                'short_description': variant_short_description,
+                'variant_data': variant_data,
+                'effect_data': effect_data,
+                'peptides': peptides,
+            }
+            variants.append(variant_dict)
+
+        template_data = {
+            'patient_info': patient_info,
+            'variants': variants,
+        }
+        template_data.update(self.output_values)
+        return template_data
 
 
 def _make_report(

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import, print_function, division
+from collections import OrderedDict
 import logging
 import os
 import tempfile
@@ -34,11 +35,25 @@ JINJA_ENVIRONMENT = jinja2.Environment(
 )
 
 
+# def compute_template_data_ordered_dicts(
+#         ranked_variants_with_vaccine_peptides,
+#         mhc_alleles,
+#         variants,
+#         bam_path):
+#     # create dictionary mapping variants to coding effects
+#     variants_to_top_coding_effect_dict = {
+#         variant: effect_collection.top_priority_effect()
+#         for (variant, effect_collection)
+#         in variants.effects().drop_silent_and_noncoding().groupby_variant().items()
+#     }
+
+
 def compute_template_data(
         ranked_variants_with_vaccine_peptides,
         mhc_alleles,
         variants,
-        bam_path):
+        bam_path,
+        output_values):
     # create dictionary mapping variants to coding effects
     variants_to_top_coding_effect_dict = {
         variant: effect_collection.top_priority_effect()
@@ -46,14 +61,20 @@ def compute_template_data(
         in variants.effects().drop_silent_and_noncoding().groupby_variant().items()
     }
 
-    template_data = {
-        'vcf_paths': "; ".join(variants.sources),
-        'bam_path': bam_path,
-        'mhc_alleles': " ".join(mhc_alleles),
-        'num_total_somatic_variants': len(variants),
-        'num_somatic_variants_with_predicted_coding_effects':
-            len(variants_to_top_coding_effect_dict),
-    }
+    # seed it with the input "output_values", later get rid of this
+    template_data = output_values
+
+    # test the theory about ordered dicts
+    patient_info = OrderedDict()
+    patient_info['Patient ID'] = output_values['patient_id']
+    patient_info['VCF (somatic variants) path(s)'] = "; ".join(variants.sources)
+    patient_info['BAM (RNAseq reads) path'] = bam_path
+    patient_info['MHC alleles'] = " ".join(mhc_alleles)
+    patient_info['Total number of somatic variants'] = len(variants)
+    patient_info['Somatic variants with predicted coding effects'] = len(variants_to_top_coding_effect_dict)
+
+    template_data['patient_info'] = patient_info
+
 
     # list ranked variants with their peptides
     variants = []

--- a/vaxrank/templates/stylesheet.css
+++ b/vaxrank/templates/stylesheet.css
@@ -55,7 +55,7 @@ col.args-column-two {
 
 }
 
-/* Variant list stuff */
+/* Variants */
 ol.main {
 	padding-left: 1.2em;
 	margin-left: 0.1em;
@@ -106,16 +106,6 @@ td.variant-head {
 	padding-left: 0.7em;
 }
 
-/* Effects */
-table.effect {
-	width: 100%;
-	border: none;
-}
-
-td.effect {
-	padding: 0;
-}
-
 /* Peptides */
 ol.peptides {
 	padding-left: 0;
@@ -128,7 +118,7 @@ li.peptide {
 
 table.peptide {
 	margin: -1em 0 2em 2em;
-	width: 90%;
+	width: 80%;
 }
 
 span.mutant {
@@ -141,12 +131,28 @@ span.mutant {
 	margin-right: 2px;
 }
 
-col.peptide-column-one {
-	width: 50%;
+table.peptide-inner {
+	width: 100%;
+	border: none;
 }
 
-col.peptide-column-two {
-	width: 50%;
+td.peptide-inner {
+	padding: 0;
+}
+
+td.peptide-inner-header {
+	font-weight: bold;
+	text-align: center;
+	font-size: 125%;
+	padding: 0.75em;
+}
+
+col.peptide-data-column-one {
+	width: 70%;
+}
+
+col.peptide-data-column-two {
+	width: 30%;
 }
 
 /* Signatures */

--- a/vaxrank/templates/template.html
+++ b/vaxrank/templates/template.html
@@ -10,243 +10,150 @@
         </style>
     </head>
     <body>
-    <div id="main">
-    	<h1 id="report-header">Vaccine Peptides Report</h1>
-    	<h3 id="patient-info">PATIENT INFO</h3>
-        <table class="pure-table pure-table-bordered patient-info">
-            <colgroup>
-                <col class="patient-info-column-one">
-                <col class="patient-info-column-two">
-            </colgroup>
-            {% for key, val in patient_info.items() %}
-            <tr>
-                <td>{{ key }}</td>
-                <td>{{ val }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-    	<br>
-        <h3 id="args">COMMAND LINE ARGUMENTS</h4>
-        <table class="pure-table pure-table-bordered args">
-            <colgroup>
-                <col class="args-column-one">
-                <col class="args-column-two">
-            </colgroup>
-            {% for a in args %}
-            <tr>
-                <td class="arg">{{ a[0] }}</td>
-                <td class="arg">{{ a[1] }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-    	<ol class="main">
-    	{% for v in variants %}
-    	<li class="variant-list-item">
-            <div class="variant-span">
-    		<table class="pure-table pure-table-bordered variant">
-    			<colgroup>
-                	<col class="variant-column-one">
-                    <col class="variant-column-two">
+        <div id="main">
+        	<h1 id="report-header">Vaccine Peptides Report</h1>
+
+        	<h3 id="patient-info">PATIENT INFO</h3>
+            <table class="pure-table pure-table-bordered patient-info">
+                <colgroup>
+                    <col class="patient-info-column-one">
+                    <col class="patient-info-column-two">
                 </colgroup>
-                <thead class="variant-head">
-                    <tr>
-                        <td class="variant-head">Variant</td>
-                        <td class="variant-head">{{ v.short_description }}</td>
-                    </tr>
+                {% for key, val in patient_info.items() %}
+                <tr><td>{{ key }}</td><td>{{ val }}</td></tr>
+                {% endfor %}
+            </table>
+        	<br>
+
+            <h3 id="args">COMMAND LINE ARGUMENTS</h4>
+            <table class="pure-table pure-table-bordered args">
+                <colgroup>
+                    <col class="args-column-one">
+                    <col class="args-column-two">
+                </colgroup>
+                {% for a in args %}
+                <tr><td class="arg">{{ a[0] }}</td><td class="arg">{{ a[1] }}</td></tr>
+                {% endfor %}
+            </table>
+        	<ol class="main">
+
+        	{% for v in variants %}
+        	<li class="variant-list-item">
+                <div class="variant-span">
+            		<table class="pure-table pure-table-bordered variant">
+            			<colgroup>
+                        	<col class="variant-column-one">
+                            <col class="variant-column-two">
+                        </colgroup>
+                        <thead class="variant-head">
+                            <tr>
+                                <td class="variant-head">Variant</td>
+                                <td class="variant-head">{{ v.short_description }}</td>
+                            </tr>
+                        </thead>
+                        {% for key, val in v.variant_data.items() %}
+                        <tr><td>{{ key }}</td><td>{{ val }}</td></tr>
+                        {% endfor %}
+                    </table>
+                    <br>
+
+                    <h4 id="effects">Predicted Effect</h4>
+                    <table class="pure-table pure-table-bordered">
+                        {% for key, val in v.effect_data.items() %}
+                        <tr><td>{{ key }}</td><td>{{ val }}</td></tr>
+                        {% endfor %}
+                	</table>
+                	<br>
+
+            		<h4 id="peptides">Vaccine Peptides for variant: {{ v.short_description }}</h4>
+            		<ol class="peptides" type="i">
+            			{% for p in v.peptides %}
+            			<li class="peptide">
+            				<table class="pure-table pure-table-bordered peptide">
+                                <thead>
+                                    <tr><td class="peptide-inner-header">{{ p.header_display_data.aa_before_mutation }}<span class="mutant">{{ p.header_display_data.aa_mutant }}</span>{{ p.header_display_data.aa_after_mutation }}</td></tr>
+                                </thead>
+                                <tr><td class="peptide-inner">
+                                    <table class="pure-table pure-table-bordered peptide-inner">
+                                        <colgroup>
+                                            <col class="peptide-data-column-one">
+                                            <col class="peptide-data-column-two">
+                                        </colgroup>
+                                        {% for key, val in p.peptide_data.items() %}
+                                        <tr><td>{{ key }}</td><td>{{ val }}</td></tr>
+                                        {% endfor %}
+                                    </table>
+                                </td></tr>
+
+                                <tr><td class="peptide-inner-header">Manufacturability</td></tr>
+                                <tr><td class="peptide-inner">
+                                    <table class="pure-table pure-table-bordered peptide-inner">
+                                        <colgroup>
+                                            <col class="peptide-data-column-one">
+                                            <col class="peptide-data-column-two">
+                                        </colgroup>
+                                        {% for key, val in p.manufacturability_data.items() %}
+                                        <tr><td>{{ key }}</td><td>{{ val }}</td></tr>
+                                        {% endfor %}
+                                    </table>
+                                </td></tr>
+
+                                <tr><td class="peptide-inner-header">Predicted mutant epitopes</td></tr>
+                                <tr><td class="peptide-inner">
+                                    <table class="pure-table peptide-inner">
+                                        <thead>
+                                            <tr>
+                                                {% for key in p.epitopes[0] %}
+                                                <td>{{ key }}</td>
+                                                {% endfor %}
+                                            </tr>
+                                        </thead>
+                                        {% for e in p.epitopes %}
+                                        <tr>
+                                            {% for _, val in e.items() %}
+                                            <td>{{ val }}</td>
+                                            {% endfor %}
+                                        </tr>
+                                        {% endfor %}
+                                    </table>
+                                </td></tr>
+                            </table>                            
+            			</li>
+            			{% endfor %}
+            		</ol>
+                </div>
+        	</li>
+        	{% endfor %}
+        	</ol>
+
+            <table class="pure-table pure-table-bordered reviewed-by">
+                <thead>
+                    <tr><td>Reviewed By</td></tr>
+                </thead>
+                {% for r in reviewers %}
+                <tr><td>{{ r }}</td></tr>
+                {% endfor %}
+            </table>
+            <br><br>
+
+            <table class="pure-table pure-table-bordered signature">
+                <thead>
+                    <tr><td>Final Review</td></tr>
                 </thead>
                 <tr>
-                    <td>Gene name</td>
-                    <td>{{ v.gene_name }}</td>
-                </tr>
-                <tr>
-                    <td>Top score</td>
-                    <td>{{ v.top_score|round(4) }}</td>
-                </tr>
-                <tr>
-                    <td>Reads supporting variant allele</td>
-                    <td>{{ v.reads_supporting_variant_allele }}</td>
-                </tr>
-                <tr>
-                    <td>Reads supporting reference allele</td>
-                    <td>{{ v.reads_supporting_reference_allele }}</td>
-                </tr>
-                <tr>
-                    <td>Reads supporting other alleles</td>
-                    <td>{{ v.reads_supporting_other_alleles }}</td>
+                    <td class="signature-inner">
+                        <table class="pure-table signature-inner">
+                            <colgroup>
+                                <col class="signature-column-one">
+                                <col class="signature-column-two">
+                            </colgroup>
+                            <tr><td>Name</td><td>{{ final_review }}</td></tr>
+                            <tr><td>Signature</td><td></td></tr>
+                            <tr><td>Date</td><td></td></tr>
+                        </table>
+                    </td>
                 </tr>
             </table>
-            <br>
-            <h4 id="effects">Predicted Effect</h4>
-            <table class="pure-table pure-table-bordered">
-        		<tr>
-        			<td>Effect type</td>
-        			<td>{{ v.predicted_effect.__class__.__name__ }}</td>
-        		</tr>
-        		<tr>
-        			<td>Transcript name</td>
-        			<td>{{ v.predicted_effect.transcript_name }}</td>
-        		</tr>
-        		<tr>
-        			<td>Transcript ID</td>
-        			<td>{{ v.predicted_effect.transcript_id }}</td>
-        		</tr>
-        		<tr>
-        			<td>Effect description</td>
-        			<td>{{ v.predicted_effect.short_description }}</td>
-        		</tr>
-        	</table>
-        	<br>
-    		<h4 id="peptides">Vaccine Peptides for variant: {{ v.short_description }}</h4>
-    		<ol class="peptides" type="i">
-    			{% for p in v.peptides %}
-    			<li class="peptide">
-    				<table class="pure-table pure-table-bordered peptide">
-    					<colgroup>
-		                	<col class="peptide-column-one">
-		                    <col class="peptide-column-two">
-		                </colgroup>
-    					<thead>
-                    		<tr>
-                        		<td>Amino acid sequence</td>
-		                        <td>{{ p.aa_before_mutation }}<span class="mutant">{{ p.aa_mutant }}</span>{{ p.aa_after_mutation }}</td>
-        	            	</tr>
-            		    </thead>
-            		    <tr>
-		        			<td>Transcript name</td>
-		        			<td>{{ v.predicted_effect.transcript_name }}</td>
-		        		</tr>
-            		    <tr>
-        	            	<td>Length</td>
-        	            	<td>{{ p.length }}</td>
-        	            </tr>
-        	            <tr>
-        	            	<td>Expression score</td>
-        	            	<td>{{ p.expression_score|round(4) }}</td>
-        	            </tr>
-        	            <tr>
-        	            	<td>Mutant epitope score</td>
-        	            	<td>{{ p.mutant_epitope_score|round(4) }}</td>
-        	            </tr>
-        	            <tr>
-        	            	<td>Reads fully spanning cDNA sequence(s)</td>
-        	            	<td>{{ p.num_alt_reads_supporting_protein_sequence }}</td>
-        	            </tr>
-        	            <tr>
-        	            	<td>Mutant amino acids</td>
-        	            	<td>{{ p.num_mutant_amino_acids }}</td>
-        	            </tr>
-        	            <tr>
-        	            	<td>Mutation distance from edge</td>
-        	            	<td>{{ p.mutation_distance_from_edge }}</td>
-        	            </tr>
-                        <tr>
-                            <th colspan="2" style="padding-top: 1em; padding-bottom: 1em;">
-                                Manufacturability
-                            </th>
-                        </tr>
-                        <tr style="border-top-width: 1px;">
-                            <td>C-terminal 7mer GRAVY score</td>
-                            <td>{{p.cterm_7mer_gravy_score|round(2)}}</td>
-                        </tr>
-                        <tr>
-                            <td>Max 7mer GRAVY score</td>
-                            <td>{{p.max_7mer_gravy_score|round(2)}}</td>
-                        </tr>
-                        <tr>
-                            <td>N-terminal Glutamine, Glutamic Acid, or Cysteine</td>
-                            <td>{{p.difficult_n_terminal_residue}}</td>
-                        </tr>
-                        <tr>
-                            <td>C-terminal Cysteine</td>
-                            <td>{{p.c_terminal_cysteine}}</td>
-                        </tr>
-                        <tr>
-                            <td>C-terminal Proline</td>
-                            <td>{{p.c_terminal_proline}}</td>
-                        </tr>
-                        <tr>
-                            <td>Total number of Cysteine residues</td>
-                            <td>{{p.cysteine_count}}</td>
-                        </tr>
-                        <tr>
-                            <td>N-terminal Asparagine</td>
-                            <td>{{p.n_terminal_asparagine}}</td>
-                        </tr>
-                         <tr>
-                            <td>Number of Asparagine-Proline bonds</td>
-                            <td>{{p.asparagine_proline_bond_count}}</td>
-                        </tr>
-        	            <tr>
-        	            	<th colspan="2" style="padding-top: 1em; padding-bottom: 1em;">
-                                Predicted mutant epitopes
-                            </th>
-                        </tr>
-                        <tr>
-        	            	<td class="effect" colspan="2">
-                    			<table class="pure-table effect">
-                    				<thead>
-                    					<tr>
-			                        		<td>Sequence</td>
-					                        <td>IC50</td>
-                                            <td>Score</td>
-					                        <td>Allele</td>
-			        	            	</tr>
-			            		    </thead>
-			            		    {% for e in p.epitopes %}
-		                    		<tr>
-        		            			<td>{{ e.sequence }}</td>
-        		            			<td>{{ e.ic50|round(2) }}</td>
-                                        <td>{{ e.normalized_binding_score|round(4)}}
-        		            			<td>{{ e.allele }}</td>
-		                    		</tr>
-		                    		{% endfor %}
-        		            	</table>
-		                    </td>
-        	            </tr>
-    				</table>
-    			</li>
-    			{% endfor %}
-    		</ol>
-            </div>
-    	</li>
-    	{% endfor %}
-    	</ol>
-        <table class="pure-table pure-table-bordered reviewed-by">
-            <thead>
-                <tr><td>Reviewed By</td></tr>
-            </thead>
-            {% for r in reviewers %}
-            <tr><td>{{ r }}</td></tr>
-            {% endfor %}
-        </table>
-        <br><br>
-        <table class="pure-table pure-table-bordered signature">
-            <thead>
-                <tr><td>Final Review</td></tr>
-            </thead>
-            <tr>
-                <td class="signature-inner">
-                    <table class="pure-table signature-inner">
-                        <colgroup>
-                            <col class="signature-column-one">
-                            <col class="signature-column-two">
-                        </colgroup>
-                        <tr>
-                            <td>Name</td>
-                            <td>{{ final_review }}</td>
-                        </tr>
-                        <tr>
-                            <td>Signature</td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <td>Date</td>
-                            <td></td>
-                        </tr>
-                    </table>
-                </td>
-            </tr>
-        </table>
-    </div>
+        </div>
     </body>
 </html>

--- a/vaxrank/templates/template.html
+++ b/vaxrank/templates/template.html
@@ -13,36 +13,18 @@
     <div id="main">
     	<h1 id="report-header">Vaccine Peptides Report</h1>
     	<h3 id="patient-info">PATIENT INFO</h3>
-    	<table class="pure-table pure-table-bordered patient-info">
+        <table class="pure-table pure-table-bordered patient-info">
             <colgroup>
                 <col class="patient-info-column-one">
                 <col class="patient-info-column-two">
             </colgroup>
-    		<tr>
-                <td>Patient ID</td>
-                <td>{{ patient_id }}</td>
-            </tr>
+            {% for key, val in patient_info.items() %}
             <tr>
-    			<td>VCF (somatic variants) path(s)</td>
-    			<td>{{ vcf_paths }}</td>
-    		</tr>
-    		<tr>
-    			<td>BAM (RNAseq reads) path</td>
-    			<td>{{ bam_path }}</td>
-    		</tr>
-    		<tr>
-    			<td>MHC alleles</td>
-    			<td>{{ mhc_alleles }}</td>
-    		</tr>
-    		<tr>
-    			<td>Total number of somatic variants</td>
-    			<td>{{ num_total_somatic_variants }}</td>
-    		</tr>
-    		<tr>
-    			<td>Somatic variants with predicted coding effects</td>
-    			<td>{{ num_somatic_variants_with_predicted_coding_effects }}</td>
-    		</tr>
-    	</table>
+                <td>{{ key }}</td>
+                <td>{{ val }}</td>
+            </tr>
+            {% endfor %}
+        </table>
     	<br>
         <h3 id="args">COMMAND LINE ARGUMENTS</h4>
         <table class="pure-table pure-table-bordered args">

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -1,8 +1,6 @@
-VCF (somatic variants) path(s): {{ vcf_paths }}
-BAM (RNAseq reads) path: {{ bam_path }}
-MHC alleles: {{ mhc_alleles }}
-Total number of somatic variants: {{ num_total_somatic_variants }}
-Somatic variants with predicted coding effects: {{ num_somatic_variants_with_predicted_coding_effects }}
+{% for key, val in patient_info.items() %}
+{{ key }}: {{ val }}
+{% endfor %}
 ---
 
 {% for v in variants %}

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -5,33 +5,24 @@
 
 {% for v in variants %}
 {{ v.num }}) {{ v.short_description }} ({{ v.gene_name }})
-        Top score: {{ v.top_score|round(2) }}
-        Predicted effect: {{ v.predicted_effect }}
-        Reads supporting variant allele: {{ v.reads_supporting_variant_allele }}
-        Reads supporting reference allele: {{ v.reads_supporting_reference_allele }}
-        Reads supporting other alleles: {{ v.reads_supporting_other_alleles }}
+        {% for key, val in v.variant_data.items() %}
+        {{ key }}: {{ val }}
+        {% endfor %}
         Vaccine Peptides:
         {% for p in v.peptides %}
-                {{ p.num }}. {{ p.aa_before_mutation }}_{{ p.aa_mutant }}_{{ p.aa_after_mutation }} (score = {{ p.score|round(2) }})
-                   - Length: {{ p.length }}
-                   - Expression score: {{ p.expression_score|round(2) }}
-                   - Mutant epitope score: {{ p.mutant_epitope_score|round(2) }}
-                   - Wildtype epitope score: {{ p.wildtype_epitope_score|round(2) }}
-                   - Reads fully spanning cDNA sequence(s): {{ p.num_alt_reads_supporting_protein_sequence }}
-                   - Mutant amino acids: {{ p.num_mutant_amino_acids }}
-                   - Mutation distance from edge: {{ p.mutation_distance_from_edge }}
-                   - C-terminal 7mer GRAVY score: {{p.cterm_7mer_gravy_score|round(2)}}
-                   - Max 7mer GRAVY score: {{p.max_7mer_gravy_score|round(2)}}
-                   - N-terminal Glutamine, Glutamic Acid, or Cysteine: {{p.difficult_n_terminal_residue}}
-                   - C-terminal Cysteine: {{p.c_terminal_cysteine}}
-                   - C-terminal Proline: {{p.c_terminal_proline}}
-                   - Total number of Cysteine residues: {{p.cysteine_count}}
-                   - N-terminal Asparagine: {{p.n_terminal_asparagine}}
-                   - Number of Asparagine-Proline bonds: {{p.asparagine_proline_bond_count}}
-                   - Predicted mutant epitopes:
-                   {% for e in p.epitopes %}
-                         * {{ e.sequence }} {{ e.ic50|round(2) }} ({{ e.allele }})
-                   {% endfor %}
+                {{ p.header_display_data.num }}. {{ p.header_display_data.aa_before_mutation }}_{{ p.header_display_data.aa_mutant }}_{{ p.header_display_data.aa_after_mutation }} (score = {{ v.variant_data["Top score"] }})
+                  {% for key, val in p.peptide_data.items() %}
+                  - {{ key }}: {{ val }}
+                  {% endfor %}
 
+                  Manufacturability:
+                  {% for key, val in p.manufacturability_data.items() %}
+                  - {{ key }}: {{ val }}
+                  {% endfor %}
+                  
+                  Predicted mutant epitopes:
+                  {% for e in p.epitopes %}
+                        * {{ e["Sequence"] }} {{ e["IC50"] }} ({{ e["Allele"] }})
+                  {% endfor %}
         {% endfor %}
 {% endfor %}


### PR DESCRIPTION
A couple of report gen changes:
    - Refactored report gen logic to use OrderedDicts. This brings all the work into the Python code, and avoids replication across templates, which now mostly just iterate over the OrderedDicts
    - Prettied up the peptide table; now "Manufacturability" and "Predicted mutant epitopes" are both subsections.

Fixes #64 