### PR TITLE
Making PDF generation work on Linux boxes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pypandoc  # needs pandoc: brew install pandoc
 shellinford>=0.3.4
 xlsxwriter
 xlrd
+xvfbwrapper

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ if __name__ == '__main__':
             'shellinford>=0.3.4',
             'xlrd',
             'xlsxwriter',
+            'xvfbwrapper',
         ],
 
         long_description=readme,

--- a/vaxrank/templates/stylesheet.css
+++ b/vaxrank/templates/stylesheet.css
@@ -1,3 +1,9 @@
+/* this is to fix HTML->PDF rendering on Debian: wkhtmltopdf screws up the 
+line heights otherwise */
+table, table.th, table.td {
+    line-height: 1.1em;
+}
+
 #main {
 	padding: 4em;
 }


### PR DESCRIPTION
- Using xvfbwrapper in PDF report gen so we can run pdfkit (which uses wkhtmltopdf) on headless servers
- Adding a fix for Debian-specific CSS formatting

Fixes #79 