### PR TITLE
Adding versions for a few relevant packages to the ASCII report.

### DIFF
--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division
 from collections import namedtuple, OrderedDict
 from copy import copy
+from importlib import import_module
 import logging
 from operator import attrgetter
 import os
@@ -325,9 +326,17 @@ class TemplateDataCreator(object):
             }
             variants.append(variant_dict)
 
+        # add package metadata to the report
+        package_versions = {}
+        for name in ['vaxrank', 'isovar', 'mhctools', 'varcode', 'pyensembl']:
+            module = import_module(name)
+            version = getattr(module, '__version__')
+            package_versions[name] = version
+
         self.template_data.update({
             'patient_info': patient_info,
             'variants': variants,
+            'package_versions': package_versions,
         })
         return self.template_data
 

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -1,6 +1,11 @@
 {% for key, val in patient_info.items() %}
 {{ key }}: {{ val }}
 {% endfor %}
+
+Package version info
+{% for key, val in package_versions.items() %}
+    {{ key }}: {{ val }}
+{% endfor %}
 ---
 
 {% for v in variants %}


### PR DESCRIPTION
Quick fix so we know what versions are running - we may want to move this to the epidisco report. In the meantime, this is what the new ASCII report header looks like:

```
Patient ID: Test Patient
VCF (somatic variants) path(s): test/data/b16.f10/b16.vcf
BAM (RNAseq reads) path: test/data/b16.f10/b16.combined.bam
MHC alleles: H-2-Kb H-2-Db
Total number of somatic variants: 4
Somatic variants with predicted coding effects: 4

Package version info
    isovar: 0.5.0
    pyensembl: 1.0.3
    varcode: 0.5.9
    vaxrank: 0.3.0
    mhctools: 0.3.1
---

1) chr9 g.82927102G>T (Phip)
... etc etc
```

Addresses #44 