### PR TITLE
use ensembl 87 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ install:
   - pip install coveralls
 script:
   - ./lint.sh
-  - pyensembl install --release 85 --species human
-  - pyensembl install --release 85 --species mouse
+  - pyensembl install --release 87 --species human
+  - pyensembl install --release 87 --species mouse
   # run tests
   - nosetests test --with-coverage --cover-package=vaxrank
 after_success:


### PR DESCRIPTION
The tests for other PRs (https://github.com/hammerlab/vaxrank/pull/117 and https://github.com/hammerlab/vaxrank/pull/118) depend on using a more recent ensembl release.