### PR TITLE
Cut edge disco cases

### DIFF
--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -49,6 +49,16 @@ def vaccine_peptides_for_variant(
         variant=variant,
         protein_sequence=isovar_protein_sequences[0])
 
+    min_expected_length = mhc_predictor.min_peptide_length
+    def_expected_length = mhc_predictor.default_peptide_lengths
+    if def_expected_length is not None and len(def_expected_length) > 0:
+        min_expected_length = min(def_expected_length)
+    if len(protein_fragment) < min_expected_length:
+        logger.info("Mutant protein fragment for %s (%s) is "
+                    "to short to be used in prediction. Skipping.",
+                    str(protein_fragment), str(variant))
+        return []
+
     logger.info(
         "Mutant protein fragment for %s: %s",
         variant,

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -495,8 +495,9 @@ def make_csv_report(
         frames[sheet_name] = df
 
     if not frames:
-        logger.info('No data for CSV or XLSX report')
-        return
+        logger.info('No data for CSV or XLSX report; creating files only with headers.')
+        empty_columns = new_columns()
+        frames['Empty'] = pd.DataFrame(empty_columns, columns=empty_columns.keys())
 
     all_dfs = pd.concat(frames.values())
     if csv_report_path:


### PR DESCRIPTION
These are pretty much edge cases but the short peptide issue affects the whole stack of mhctools family in various ways:

## Short peptide sequences
I have been getting `assertion` erros on the mhctools for a handful of patients and no matter what I did (restart, upgrade, manual run), none of them solved the issue. I was able to track down the issue to the following case:

```shell
# version 0.4.4
$ vaxrank --mhc-predictor netmhccons --mhc-alleles $ANY_ALLELE --bam $ANY_BAM --genome GRCh37 --variant 3 53925802 G T
....
2017-06-10 22:06:04,478 - vaxrank.core_logic:55 - INFO - Mutant protein fragment for Variant(contig='3', start=53925802, ref='G', alt='T', reference_name='GRCh37'): MutantProteinFragment(variant=Variant(contig='3', start=53925802, ref='G', alt='T', reference_name='GRCh37'), gene_name='SELK', amino_acids='MVYI', mutant_amino_acid_start_offset=4, mutant_amino_acid_end_offset=5, supporting_reference_transcripts=[Transcript(transcript_id=ENST00000495461, name=SELK-001, gene_id=ENSG00000113811, gene_name=SELK, biotype=protein_coding, location=3:53918437-53926015), Transcript(transcript_id=ENST00000541726, name=SELK-201, gene_id=ENSG00000113811, gene_name=SELK, biotype=protein_coding, location=3:53919227-53925989)], n_overlapping_reads=280, n_alt_reads=75, n_ref_reads=205, n_alt_reads_supporting_protein_sequence=69)
Traceback (most recent call last):
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/bin/vaxrank", line 11, in <module>
    sys.exit(main())
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/vaxrank/cli.py", line 285, in main
    data = ranked_variant_list_with_metadata(args)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/vaxrank/cli.py", line 227, in ranked_variant_list_with_metadata
    variant_sequence_assembly=args.variant_sequence_assembly)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/vaxrank/core_logic.py", line 191, in ranked_vaccine_peptides
    min_epitope_score=min_epitope_score)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/vaxrank/core_logic.py", line 164, in generate_vaccine_peptides
    min_epitope_score=min_epitope_score)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/vaxrank/core_logic.py", line 61, in vaccine_peptides_for_variant
    genome=variant.ensembl).values()
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/vaxrank/epitope_prediction.py", line 168, in predict_epitopes
    {protein_fragment.gene_name: protein_fragment.amino_acids})
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/mhctools/base_predictor.py", line 208, in predict_subsequences
    binding_predictions = self.predict_peptides(peptide_list)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/mhctools/base_commandline_predictor.py", line 316, in predict_peptides
    temp_dir_list=dirs)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/mhctools/base_commandline_predictor.py", line 262, in _run_commands_and_collect_predictions
    process_limit=self.process_limit)
  File "/nfs-pool/workdir/toolkit/python-tools/envs/vaxrank.0.4.4/lib/python3.6/site-packages/mhctools/process_helpers.py", line 114, in run_multiple_commands_redirect_stdout
    assert len(multiple_args_dict) > 0
AssertionError
```

This is happening because of an early truncation on the protein product (`SELK-001`), making it way shorter to be able to run prediction on it: `MVYI`. We actually need to address this both on the vaxrank and then on the `mhctools` side, because it is closely related to #131 and #122.

Here is another variant that leads a similar failure: `--variant 15 42696996 G C` (Protein: `CAPN3`, product: `` [yep, empty])

## Missing output reports
The issue here was that epidisco was defining all the report outputs as the product of the vaxrank workflow and I realized that quite a lot of my vaxrank jobs were failing because of `successfully run but didn't ensure condition.`. Looking at the output folder, I realized that vaxrank was not creating any files when there were no results found, but it actually should (both for epidisco and for the semantics of it). So I force it create those files now :)