### PR TITLE
Removing the default limit on the number of mutations in report

### DIFF
--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -152,7 +152,6 @@ def add_vaccine_peptide_args(arg_parser):
 
     vaccine_peptide_group.add_argument(
         "--max-mutations-in-report",
-        default=10,
         type=int,
         help="Number of mutations to report")
 


### PR DESCRIPTION
Fixes #73 