### PR TITLE
Some changes in preparation for computing a minimal epitope report:

### DIFF
--- a/run-vaxrank-b16-test-data.sh
+++ b/run-vaxrank-b16-test-data.sh
@@ -6,6 +6,7 @@ vaxrank \
     --mhc-alleles H2-Kb,H2-Db \
     --mhc-epitope-lengths 8 \
     --padding-around-mutation 5 \
+    --min-epitope-score 0.0 \
     --output-ascii-report vaccine-peptides-report.txt \
     --output-html-report vaccine-peptides-report.html \
     --output-pdf-report vaccine-peptides-report.pdf \

--- a/test/test_epitope_prediction.py
+++ b/test/test_epitope_prediction.py
@@ -18,7 +18,8 @@ from nose.tools import eq_, ok_
 
 from mhctools import RandomBindingPredictor
 from pyensembl import EnsemblRelease
-from vaxrank.epitope_prediction import predict_epitopes, logistic_epitope_score
+from varcode import Variant
+from vaxrank.epitope_prediction import predict_epitopes
 from vaxrank.mutant_protein_fragment import MutantProteinFragment
 from vaxrank.vaccine_peptide import VaccinePeptide
 
@@ -28,7 +29,7 @@ def test_reference_peptide_logic():
     wdr13_transcript = genome.transcripts_by_name("Wdr13-001")[0]
 
     protein_fragment = MutantProteinFragment(
-        variant=None,  # irrelevant to test
+        variant=Variant('X', '8125624', 'C', 'A'),
         gene_name='Wdr13',
         amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
         mutant_amino_acid_start_offset=12,
@@ -56,9 +57,9 @@ def test_reference_peptide_logic():
         protein_fragment,
         [prediction_occurs_in_reference, prediction_does_not_occur_in_reference])
 
-    eq_(logistic_epitope_score(prediction_occurs_in_reference),
+    eq_(prediction_occurs_in_reference.logistic_epitope_score(),
         vaccine_peptide.wildtype_epitope_score)
-    eq_(logistic_epitope_score(prediction_does_not_occur_in_reference),
+    eq_(prediction_does_not_occur_in_reference.logistic_epitope_score(),
         vaccine_peptide.mutant_epitope_score)
 
 def test_mhc_predictor_error():
@@ -66,7 +67,7 @@ def test_mhc_predictor_error():
     wdr13_transcript = genome.transcripts_by_name("Wdr13-001")[0]
 
     protein_fragment = MutantProteinFragment(
-        variant=None,  # irrelevant to test
+        variant=Variant('X', '8125624', 'C', 'A'),
         gene_name='Wdr13',
         amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
         mutant_amino_acid_start_offset=12,

--- a/test/test_mutant_protein_sequence.py
+++ b/test/test_mutant_protein_sequence.py
@@ -25,7 +25,7 @@ from .testing_helpers import data_path
 
 
 def check_mutant_amino_acids(variant, mutant_protein_fragment):
-    predicted_effect = variant.effects().top_priority_effect()
+    predicted_effect = mutant_protein_fragment.predicted_effect()
     expected_amino_acids = predicted_effect.aa_alt
     vaxrank_mutant_amino_acids = mutant_protein_fragment.amino_acids[
         mutant_protein_fragment.mutant_amino_acid_start_offset:

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -133,7 +133,8 @@ def add_output_args(arg_parser):
     output_args_group.add_argument(
         "--output-min-epitope-report",
         default="",
-        help="Path to the minimal epitope report")
+        help="Path to the minimal epitope report, which lists which mutant and wildtype peptides "
+        "can be used for T-cell response assays")
 
 
 def add_vaccine_peptide_args(arg_parser):

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -37,6 +37,7 @@ from .report import (
     make_html_report,
     make_pdf_report,
     make_csv_report,
+    make_min_epitope_report,
     TemplateDataCreator,
     PatientInfo,
 )
@@ -128,6 +129,11 @@ def add_output_args(arg_parser):
         "--log-path",
         default="python.log",
         help="File path to write the vaxrank Python log to")
+
+    output_args_group.add_argument(
+        "--output-min-epitope-report",
+        default="",
+        help="Path to the minimal epitope report")
 
 
 def add_vaccine_peptide_args(arg_parser):
@@ -292,6 +298,9 @@ def main(args_list=None):
     ranked_variant_list = data['variants']
     patient_info = data['patient_info']
     args_for_report = data['args']
+
+    if args.output_min_epitope_report:
+        make_min_epitope_report(ranked_variant_list, args.output_min_epitope_report)
 
     ###################
     # CSV-based reports

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -25,9 +25,10 @@ import six
 
 logger = logging.getLogger(__name__)
 
-EpitopePrediction = namedtuple("EpitopePrediction", [
+EpitopePredictionBase = namedtuple("EpitopePrediction", [
     "allele",
     "peptide_sequence",
+    "wt_peptide_sequence",
     "length",
     "ic50",
     "percentile_rank",
@@ -38,34 +39,36 @@ EpitopePrediction = namedtuple("EpitopePrediction", [
     "occurs_in_reference",
 ])
 
-def logistic_epitope_score(
-        epitope_prediction,
-        midpoint=350.0,
-        width=150.0,
-        ic50_cutoff=2000.0):
-    """
-    Map from IC50 values to score where 1.0 = strong binder, 0.0 = weak binder
-    Default midpoint and width for logistic determined by max likelihood fit
-    for data from Alessandro Sette's 1994 paper:
+class EpitopePrediction(EpitopePredictionBase):
 
-       "The relationship between class I binding affinity
-        and immunogenicity of potential cytotoxic T cell epitopes.
+    def logistic_epitope_score(
+            self,
+            midpoint=350.0,
+            width=150.0,
+            ic50_cutoff=2000.0):
+        """
+        Map from IC50 values to score where 1.0 = strong binder, 0.0 = weak binder
+        Default midpoint and width for logistic determined by max likelihood fit
+        for data from Alessandro Sette's 1994 paper:
 
-    TODO: Use a large dataset to find MHC binding range predicted to #
-    correlate with immunogenicity
-    """
-    if epitope_prediction.ic50 >= ic50_cutoff:
-        return 0.0
+           "The relationship between class I binding affinity
+            and immunogenicity of potential cytotoxic T cell epitopes.
 
-    rescaled = (float(epitope_prediction.ic50) - midpoint) / width
-    # simplification of 1.0 - logistic(x) = logistic(-x)
-    logistic = 1.0 / (1.0 + np.exp(rescaled))
+        TODO: Use a large dataset to find MHC binding range predicted to #
+        correlate with immunogenicity
+        """
+        if self.ic50 >= ic50_cutoff:
+            return 0.0
 
-    # since we're scoring IC50 values, let's normalize the output
-    # so IC50 near 0.0 always returns a score of 1.0
-    normalizer = 1.0 / (1.0 + np.exp(-midpoint / width))
+        rescaled = (float(self.ic50) - midpoint) / width
+        # simplification of 1.0 - logistic(x) = logistic(-x)
+        logistic = 1.0 / (1.0 + np.exp(rescaled))
 
-    return logistic / normalizer
+        # since we're scoring IC50 values, let's normalize the output
+        # so IC50 near 0.0 always returns a score of 1.0
+        normalizer = 1.0 / (1.0 + np.exp(-midpoint / width))
+
+        return logistic / normalizer
 
 def fm_index_path(genome):
     """
@@ -193,9 +196,22 @@ def predict_epitopes(
         overlaps_mutation = protein_fragment.interval_overlaps_mutation(
             start_offset=peptide_start_offset,
             end_offset=peptide_end_offset)
+
+        # compute WT epitope sequence, if this epitope overlaps the mutation
+        if overlaps_mutation:
+            full_reference_protein_sequence = (
+                protein_fragment.predicted_effect().original_protein_sequence
+            )
+            global_epitope_start_pos = protein_fragment.global_start_pos() + peptide_start_offset
+            wt_peptide = full_reference_protein_sequence[
+                global_epitope_start_pos:global_epitope_start_pos + binding_prediction.length]
+        else:
+            wt_peptide = peptide
+
         epitope_prediction = EpitopePrediction(
                 allele=binding_prediction.allele,
                 peptide_sequence=peptide,
+                wt_peptide_sequence=wt_peptide,
                 length=len(binding_prediction.peptide),
                 ic50=binding_prediction.value,
                 percentile_rank=binding_prediction.percentile_rank,
@@ -204,7 +220,7 @@ def predict_epitopes(
                 source_sequence=protein_fragment.amino_acids,
                 offset=binding_prediction.offset,
                 occurs_in_reference=occurs_in_reference)
-        if logistic_epitope_score(epitope_prediction) >= min_epitope_score:
+        if epitope_prediction.logistic_epitope_score() >= min_epitope_score:
             key = (epitope_prediction.peptide_sequence, epitope_prediction.allele)
             results[key] = epitope_prediction
 
@@ -223,6 +239,7 @@ def slice_epitope_predictions(
         EpitopePrediction(
             allele=p.allele,
             peptide_sequence=p.peptide_sequence,
+            wt_peptide_sequence=p.wt_peptide_sequence,
             length=p.length,
             ic50=p.ic50,
             percentile_rank=p.percentile_rank,

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -15,8 +15,12 @@
 from __future__ import absolute_import, print_function, division
 
 from collections import namedtuple
+import logging
 
 from varcode.effects import top_priority_effect
+
+
+logger = logging.getLogger(__name__)
 
 # using a namedtuple base class for the immutable fields of a MutantProteinFragment
 # since it makes it clearer what the essential information is and provides

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import, print_function, division
 
 from collections import namedtuple
 
+from varcode.effects import top_priority_effect
+
 # using a namedtuple base class for the immutable fields of a MutantProteinFragment
 # since it makes it clearer what the essential information is and provides
 # useful comparison/hashing methods
@@ -166,3 +168,23 @@ class MutantProteinFragment(MutantProteinFragmentBase):
         subsequences = list(self.generate_subsequences(subsequence_length))
         subsequences.sort(key=sort_key)
         return subsequences[:k]
+
+    def predicted_effect(self):
+        effects = [self.variant.effect_on_transcript(t) for t in
+            self.supporting_reference_transcripts]
+        predicted_effect = top_priority_effect(effects)
+        return predicted_effect
+
+    def global_start_pos(self):
+        # position of mutation start relative to the full amino acid sequence
+        global_mutation_start_pos = self.predicted_effect().aa_mutation_start_offset
+        if global_mutation_start_pos is None:
+            logger.error('Could not find mutation start pos for variant %s',
+                self.variant)
+            return -1
+
+        # get the global position of the mutant protein fragment: shift left by the amount of
+        # the relative mutant start position
+        return (
+            global_mutation_start_pos - self.mutant_amino_acid_start_offset
+        )

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -30,7 +30,6 @@ from varcode import load_vcf_fast
 from varcode.effects import top_priority_effect
 
 from .manufacturability import ManufacturabilityScores
-from .epitope_prediction import logistic_epitope_score
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +215,7 @@ class TemplateDataCreator(object):
             ('Sequence', epitope_prediction.peptide_sequence),
             ('IC50', epitope_prediction.ic50),
             ('Normalized binding score', round(
-                logistic_epitope_score(epitope_prediction), 4)),
+                epitope_prediction.logistic_epitope_score(), 4)),
             ('Allele', epitope_prediction.allele),
         ])
         return epitope_data
@@ -285,9 +284,7 @@ class TemplateDataCreator(object):
 
             top_peptide = vaccine_peptides[0]
             variant_data = self._variant_data(top_peptide)
-            effects = [variant.effect_on_transcript(t) for t in
-                top_peptide.mutant_protein_fragment.supporting_reference_transcripts]
-            predicted_effect = top_priority_effect(effects)
+            predicted_effect = top_peptide.mutant_protein_fragment.predicted_effect()
             effect_data = self._effect_data(predicted_effect)
 
             databases = self._databases(
@@ -525,3 +522,21 @@ def make_csv_report(
 
         writer.save()
         logger.info('Wrote manufacturer XLSX file to %s', excel_report_path)
+
+def make_min_epitope_report(
+        ranked_variants_with_vaccine_peptides,
+        min_epitope_report_path):
+    # import pdb; pdb.set_trace()
+    # "column with the wt and its affinity next to the mutant min variant?
+    # Also is there a way to see if there are any non-variant related wt within the SLP
+    # with high affinity that we did not account for?"
+    # in practice, we want for each variant/vaccine peptide combination:
+    # - each mutant epitope included in the report needs to list its WT epitope and affinity
+    # - list all strong binders in the peptide that don't overlap the mutation
+
+    # all predictions, including WT ones, in:
+    # ranked_variants_with_vaccine_peptides[0][1][0].epitope_predictions
+    # each highly-ranked mutant epitope should also have a WT version that we want to run
+    # prediction numbers for
+    pass
+

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -526,17 +526,4 @@ def make_csv_report(
 def make_min_epitope_report(
         ranked_variants_with_vaccine_peptides,
         min_epitope_report_path):
-    # import pdb; pdb.set_trace()
-    # "column with the wt and its affinity next to the mutant min variant?
-    # Also is there a way to see if there are any non-variant related wt within the SLP
-    # with high affinity that we did not account for?"
-    # in practice, we want for each variant/vaccine peptide combination:
-    # - each mutant epitope included in the report needs to list its WT epitope and affinity
-    # - list all strong binders in the peptide that don't overlap the mutation
-
-    # all predictions, including WT ones, in:
-    # ranked_variants_with_vaccine_peptides[0][1][0].epitope_predictions
-    # each highly-ranked mutant epitope should also have a WT version that we want to run
-    # prediction numbers for
-    pass
-
+    raise NotImplementedError('Will do soon, see https://github.com/hammerlab/vaxrank/issues/142')

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -20,7 +20,6 @@ from collections import namedtuple
 import numpy as np
 
 from .manufacturability import ManufacturabilityScores
-from .epitope_prediction import logistic_epitope_score
 
 VaccinePeptideBase = namedtuple(
     "VaccinePeptide", [
@@ -41,11 +40,11 @@ class VaccinePeptide(VaccinePeptideBase):
             epitope_predictions,
             min_epitope_score=0):
         wildtype_epitope_score = sum(
-            logistic_epitope_score(p)
+            p.logistic_epitope_score()
             for p in epitope_predictions
             if not p.overlaps_mutation or p.occurs_in_reference)
         mutant_epitope_score = sum(
-            logistic_epitope_score(p)
+            p.logistic_epitope_score()
             for p in epitope_predictions
             if p.overlaps_mutation and not p.occurs_in_reference)
         return VaccinePeptideBase.__new__(


### PR DESCRIPTION
- making EpitopePrediction a class, moving logistic_epitope_score into its methods, adding a wildtype peptide to its members (reference epitope computation logic borrowed from TESLA code, see https://github.com/hammerlab/tesla/blob/df7bfdb6241899d9b4fa2bb1dc359c2ad4935979/tesla/cli.py#L81)
- adding a predicted_effect() method to MutantProteinFragment, changing a couple places in the code to use that for computing the top priority effect of a variant given a mutant protein fragment; also adding a global_start_pos() method (see same TESLA code for reference)
- adding a hook into the CLI to make a min epitope report, not implemented yet
- setting --min-epitope-score to 0.0 in the test script so I can see multiple variants

Start of work for #142 