### PR TITLE
Travis config updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ python:
   - "2.7"
   - "3.5"
 cache:
-  pip: true
-  # cache directory used for Ensembl downloads of GTF and FASTA files
+  # cache pip files, also directory used for Ensembl downloads of GTF and FASTA files
   # along with the indexed db of intervals and ID mappings and pickles
   # of sequence dictionaries
-  directories: /home/travis/.cache/pyensembl/
+  directories:
+    - $HOME/.cache/pyensembl
+    - $HOME/.cache/pip
 before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
@@ -53,10 +54,11 @@ install:
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls
-script:
-  - ./lint.sh
+before_script:
   - pyensembl install --release 87 --species human
   - pyensembl install --release 87 --species mouse
+script:
+  - ./lint.sh
   # run tests
   - travis_wait nosetests -sv test -a '!skip' --with-coverage --cover-package=vaxrank
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
   # along with the indexed db of intervals and ID mappings and pickles
   # of sequence dictionaries
   directories:
-    - $HOME/.cache/pyensembl
-    - $HOME/.cache/pip
+    - /home/travis/.cache/pyensembl/
+    - /home/travis/.cache/pip
 before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false  # Use container-based infrastructure
 language: python
 python:
@@ -43,13 +44,10 @@ addons:
     packages:
     # Needed for NetMHC
     - tcsh
-    # install pandoc for use with pypandoc for converting the README
-    # from markdown to RST
-    - pandoc
 install:
   - >
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-      numpy scipy nose pandas pylint
+      numpy scipy nose pandas pylint pandoc
   - source activate test-environment
   - pip install pypandoc
   - pip install -r requirements.txt
@@ -60,6 +58,14 @@ script:
   - pyensembl install --release 87 --species human
   - pyensembl install --release 87 --species mouse
   # run tests
-  - travis_wait nosetests test -a '!skip' --with-coverage --cover-package=vaxrank
+  - travis_wait nosetests -sv test -a '!skip' --with-coverage --cover-package=vaxrank
 after_success:
   coveralls
+deploy:
+  provider: pypi
+  distributions: sdist
+  user: hammerlab
+  password: # See http://docs.travis-ci.com/user/encryption-keys/
+    secure: "TZrNOmCEXd1NMn0k73CwjaN84dCw9VPITE3FXJJ1+PE11fNLBOnDeJd5xVWPNw+PmJir9KuincUwxhNldvwJFNFIUqdmdDB1C5E3mmYe90IK4xWBdtr7nn1iV393bFao2p8rVP5Ari0rsk3ntUa06PA232ElXnPt/m/TBj9s04Uqw1ItnEVvX9FyEaYcBjU5Wv0Y8NPtlXvXuzeZ4i8lHJh/qJ9xYbYdYCtbz5H/q5vC1XvMnWU69iN2HsxtQ9uPHoUmlQ3IpJXBHAfUCqbws/XacsFpdfdpb/BNsFTaDQiWtN5FOc2ByFT693+SqDNES1qyO0boTGJ1wlQjOT2PPFd3ynK7j0c/mvlBWD/odFeLxPLWXWn0WnJ3qQ4P9UbPcc4YbyzkXW/7W/dnkpeetDaBErXEc2P/w4UKDvg9HTBNWIIQjS0KKGQ6D+9xmpGzObP9nQ7YaSWRbP6Dux+JR0m7QXRZikPryAdLOIuUe3BTTB5GKS221ad9cUB3qsQSno2h6iiY47D2ajBFggC4Mte9Eqlc7S/+Sm2vcG5iIjKSQZRZXSrwejv0qfOaBnKEgXhgFcY/YJ4RRqRDv11ByVC9f1k/XKQb3gEY8rZbL3nJrBJQetB5n5sNsqfBM8fDn3SlIDyClj64yQqdmpgzr9/9zxYC85O73W0QvCL/XxU="
+  on:
+    branch: master


### PR DESCRIPTION
- adding auto-deploy to PyPi, assuming version increment
- using Trusty
- updating cache config, should be a no-op except maybe successfully caching pip files now
- installing pandoc with Conda instead of add-ons; necessary for correct README md -> rst conversion
- moving pyensembl installs into a `before_script` section
