### PR TITLE
Small report fixes

### DIFF
--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -244,6 +244,8 @@ def ranked_variant_list_with_metadata(args):
     if hasattr(args, 'input_json_file'):
         with open(args.input_json_file) as f:
             data = serializable.from_json(f.read())
+            # the JSON data from the previous run will have the older args saved, which may need to
+            # be overridden with args from this run (which all be output related)
             data['args'].update(vars(args))
             return data
 

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -244,6 +244,7 @@ def ranked_variant_list_with_metadata(args):
     if hasattr(args, 'input_json_file'):
         with open(args.input_json_file) as f:
             data = serializable.from_json(f.read())
+            data['args'].update(vars(args))
             return data
 
     # get various things from user args

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -301,7 +301,6 @@ class TemplateDataCreator(object):
             databases = self._databases(
                 variant, predicted_effect, top_peptide.mutant_protein_fragment.gene_name)
 
-            logger.info(variant)
             peptides = []
             for j, vaccine_peptide in enumerate(vaccine_peptides):
                 if not peptide_contains_epitopes(vaccine_peptide):

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -215,6 +215,11 @@ class TemplateDataCreator(object):
         """
         Returns an OrderedDict with epitope data from the given prediction.
         """
+        # if the WT peptide is too short, it's possible that we're missing a prediction for it
+        if epitope_prediction.wt_ic50 != None:
+            wt_ic50_str = '%.2f nM' % epitope_prediction.wt_ic50
+        else:
+            wt_ic50_str = 'No prediction'
         epitope_data = OrderedDict([
             ('Sequence', epitope_prediction.peptide_sequence),
             ('IC50', '%.2f nM' % epitope_prediction.ic50),
@@ -222,7 +227,7 @@ class TemplateDataCreator(object):
                 epitope_prediction.logistic_epitope_score(), 4)),
             ('Allele', epitope_prediction.allele.replace('HLA-', '')),
             ('WT sequence', epitope_prediction.wt_peptide_sequence),
-            ('WT IC50', '%.2f nM' % epitope_prediction.wt_ic50),
+            ('WT IC50', wt_ic50_str),
         ])
         return epitope_data
 
@@ -296,6 +301,7 @@ class TemplateDataCreator(object):
             databases = self._databases(
                 variant, predicted_effect, top_peptide.mutant_protein_fragment.gene_name)
 
+            logger.info(variant)
             peptides = []
             for j, vaccine_peptide in enumerate(vaccine_peptides):
                 if not peptide_contains_epitopes(vaccine_peptide):


### PR DESCRIPTION
- Correcting for cases where WT epitopes are too short to have binding predictions (right now this crashes the report)
- Fix to report args: respect new output args in case of generating a report from a JSON file